### PR TITLE
Polish admin itinerary and preview controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import dayjs from "dayjs";
+import "dayjs/locale/es";
 import { emitAll, openDisplayWindow, emitAnnouncement } from "./displayChannel";
 import { PanelToastHost, panelNotify } from './notificationsPanel';
 import { useAuth } from './auth';
@@ -46,6 +47,7 @@ export interface Tournament {
 
 export type SortBy = "created" | "eta" | "name" | "game";
 export type TimeFmt = '24' | '12';
+export type PanelMode = 'advanced' | 'simple';
 
 /* ====================== Helpers ====================== */
 const pad2 = (n: number) => n.toString().padStart(2, "0");
@@ -58,6 +60,8 @@ const format = (ms: number) => {
 };
 const uid = () => Math.random().toString(36).slice(2);
 const fmtClock = (tf: TimeFmt) => tf === '12' ? 'hh:mm A' : 'HH:mm';
+
+dayjs.locale("es");
 
 /* Pequeño reloj global local (sin crear archivo nuevo) */
 const useClock = (step = 250) => {
@@ -175,20 +179,29 @@ const computeETAClock = (t: Tournament, tf: TimeFmt, nowMs?: number) => {
   return dayjs((nowMs ?? Date.now()) + ms).format(fmtClock(tf));
 };
 
-const computeSchedule = (t: Tournament, tf: TimeFmt, nowMs?: number) => {
+const computeSchedule = (t: Tournament, tf: TimeFmt, nowMs?: number, limit = 3) => {
   const items: { label: string; time: string }[] = [];
   let base = nowMs ?? Date.now();
   const { inRound, currentIndex } = computeRoundsInfo(t);
   const remainingMs = (t.timer.target && (t.timer.running || t.timer.remainingMs > 0))
     ? (nowMs !== undefined ? getRemainingMs(t, nowMs) : t.timer.remainingMs)
     : 0;
-  if (remainingMs > 0) { items.push({ label: t.timer.mode === 'break' ? 'Fin break' : `Fin ronda ${inRound ? currentIndex : currentIndex + 1}` , time: dayjs(base + remainingMs).format(fmtClock(tf)) }); base += remainingMs; }
+  if (remainingMs > 0) {
+    items.push({
+      label: t.timer.mode === 'break' ? 'Fin del descanso' : `Fin ronda ${inRound ? currentIndex : currentIndex + 1}`,
+      time: dayjs(base + remainingMs).format(fmtClock(tf)),
+    });
+    base += remainingMs;
+  }
   const left = Math.max(0, t.roundsTotal - (inRound ? currentIndex : currentIndex));
   for (let i = 1; i <= left; i++) {
-    if (t.breakEnabled && t.breakMinutes > 0) { base += t.breakMinutes * 60_000; items.push({ label: `Break`, time: dayjs(base).format(fmtClock(tf)) }); }
+    if (t.breakEnabled && t.breakMinutes > 0) {
+      base += t.breakMinutes * 60_000;
+      items.push({ label: `Descanso`, time: dayjs(base).format(fmtClock(tf)) });
+    }
     base += t.roundMinutes * 60_000; items.push({ label: `Fin ronda ${currentIndex + i}`, time: dayjs(base).format(fmtClock(tf)) });
   }
-  return items.slice(0, 3);
+  return typeof limit === 'number' && limit > 0 ? items.slice(0, limit) : items;
 };
 
 /* ====================== Comunes UI ====================== */
@@ -204,6 +217,7 @@ const TournamentOffcanvas: React.FC<{ open:boolean; onClose:()=>void; onSubmit:(
   const set = (patch: Partial<ModalData>) => setForm(f=>({...f, ...patch}));
 
   if(!open) return null;
+
   return (
     <>
       <div className="offcanvas offcanvas-end show text-bg-dark" style={{visibility:'visible'}}>
@@ -253,7 +267,7 @@ const TournamentOffcanvas: React.FC<{ open:boolean; onClose:()=>void; onSubmit:(
               </select>
             </div>
             <div className="col-6 col-xl-3">
-              <label className="form-label">Break (min)</label>
+              <label className="form-label">Descanso (min)</label>
               <input type="number" className="form-control" min={0} value={form.breakMinutes} onChange={e=>set({breakMinutes: Math.max(0, Number(e.target.value))})} disabled={!form.breakEnabled} />
             </div>
             <div className="col-6 col-xl-3">
@@ -277,8 +291,22 @@ const TournamentOffcanvas: React.FC<{ open:boolean; onClose:()=>void; onSubmit:(
 };
 
 /* ====================== Offcanvas Ajustes ====================== */
-interface Settings { timeFmt: TimeFmt; cols: 1|2|3; soundEnabled: boolean; warn1m: boolean; autoOpenDisplay: boolean; }
-const defaultSettings: Settings = { timeFmt: '24', cols: 1, soundEnabled: true, warn1m: true, autoOpenDisplay: false };
+interface Settings { timeFmt: TimeFmt; cols: 1|2|3; soundEnabled: boolean; warn1m: boolean; autoOpenDisplay: boolean; panelMode: PanelMode; }
+const defaultSettings: Settings = { timeFmt: '24', cols: 1, soundEnabled: true, warn1m: true, autoOpenDisplay: false, panelMode: 'advanced' };
+const parseSettings = (value: unknown): Settings => {
+  if (!value || typeof value !== 'object') return defaultSettings;
+  const raw = value as Partial<Settings> & Record<string, unknown>;
+  const cols = raw.cols === 2 ? 2 : raw.cols === 3 ? 3 : 1;
+  const timeFmt: TimeFmt = raw.timeFmt === '12' ? '12' : '24';
+  return {
+    timeFmt,
+    cols,
+    soundEnabled: raw.soundEnabled !== undefined ? !!raw.soundEnabled : defaultSettings.soundEnabled,
+    warn1m: raw.warn1m !== undefined ? !!raw.warn1m : defaultSettings.warn1m,
+    autoOpenDisplay: raw.autoOpenDisplay !== undefined ? !!raw.autoOpenDisplay : defaultSettings.autoOpenDisplay,
+    panelMode: raw.panelMode === 'simple' ? 'simple' : 'advanced',
+  };
+};
 
 const SettingsOffcanvas: React.FC<{ open:boolean; onClose:()=>void; value:Settings; onChange:(s:Settings)=>void }>=({open,onClose,value,onChange})=>{
   const [s, setS] = useState<Settings>(value);
@@ -307,6 +335,13 @@ const SettingsOffcanvas: React.FC<{ open:boolean; onClose:()=>void; value:Settin
                 <option value={1}>1</option>
                 <option value={2}>2</option>
                 <option value={3}>3</option>
+              </select>
+            </div>
+            <div className="col-12">
+              <label className="form-label">Modo del panel</label>
+              <select className="form-select" value={s.panelMode} onChange={e=>set({ panelMode: e.target.value as PanelMode })}>
+                <option value="advanced">Avanzado</option>
+                <option value="simple">Simple</option>
               </select>
             </div>
             <div className="col-12">
@@ -353,25 +388,126 @@ type HeaderHUDProps = {
   tournaments: Tournament[];
   runningCount: number;
   anyRunning: boolean;
-  onPauseAll: ()=>void;
-  onResumeAll: ()=>void;
   onResetAll: ()=>void;
   onNew: ()=>void;
-  onCopySchedule: ()=>void;
+  onOpenItinerary: ()=>void;
   onExport: ()=>void;
   onOpenSettings: ()=>void;
   fileInputRef: React.RefObject<HTMLInputElement>;
   importJSON: (f: File)=>void;
-  AnnouncementBtn: React.FC<{ pushToast:(t:{kind:any;text:string})=>void }>;
+  AnnouncementBtn: React.FC<{ pushToast:(t:{kind:any;text:string})=>void; afterOpen?: ()=>void; className?: string }>;
   pushToast: (t:{kind:any;text:string})=>void;
 };
 
 const HeaderHUD: React.FC<HeaderHUDProps> = ({
-  now, nowMs, user, onLock, onLogout, settings, setSettings, tournaments, runningCount, anyRunning,
-  onPauseAll, onResumeAll, onResetAll, onNew, onCopySchedule, onExport, onOpenSettings,
+  now: nowLabel, nowMs, user, onLock, onLogout, settings, setSettings, tournaments, runningCount, anyRunning,
+  onResetAll, onNew, onOpenItinerary, onExport, onOpenSettings,
   fileInputRef, importJSON, AnnouncementBtn, pushToast
 }) => {
   const total = tournaments.length;
+  const simpleMode = settings.panelMode === 'simple';
+  const [moreOpen, setMoreOpen] = useState(false);
+  const moreMenuRef = useRef<HTMLDivElement | null>(null);
+  const moreBtnRef = useRef<HTMLButtonElement | null>(null);
+
+  const closeMore = useCallback(() => setMoreOpen(false), []);
+  const toggleMore = () => setMoreOpen(prev => !prev);
+
+  useEffect(() => {
+    if (!moreOpen) return;
+    const onPointer = (e: PointerEvent) => {
+      const target = e.target as Node | null;
+      if (moreMenuRef.current && moreMenuRef.current.contains(target)) return;
+      if (moreBtnRef.current && moreBtnRef.current.contains(target)) return;
+      closeMore();
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeMore();
+    };
+    window.addEventListener('pointerdown', onPointer);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('pointerdown', onPointer);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [moreOpen, closeMore]);
+
+  const requestImport = () => {
+    closeMore();
+    fileInputRef.current?.click();
+  };
+
+  const handleExport = () => {
+    closeMore();
+    onExport();
+  };
+
+  const handleSettings = () => {
+    closeMore();
+    onOpenSettings();
+  };
+
+  const handleAnnouncement = () => {
+    closeMore();
+  };
+
+  const handleLock = () => {
+    closeMore();
+    onLock();
+  };
+
+  const handleLogout = () => {
+    closeMore();
+    onLogout();
+  };
+
+  const renderMoreMenu = () => {
+    if (!moreOpen) {
+      moreMenuRef.current = null;
+      return null;
+    }
+    return (
+      <div
+        className="header-menu shadow"
+        role="menu"
+        ref={el => {
+          if (moreOpen) moreMenuRef.current = el;
+        }}
+      >
+        <div className="header-menu__section">
+          <button type="button" className="header-menu__item" onClick={requestImport}>
+            📥 Importar JSON
+          </button>
+          <button type="button" className="header-menu__item" onClick={handleExport}>
+            📤 Exportar JSON
+          </button>
+          <button type="button" className="header-menu__item" onClick={() => { closeMore(); onOpenItinerary(); }}>
+            🗓 Ver itinerario
+          </button>
+          <button type="button" className="header-menu__item" onClick={handleSettings}>
+            ⚙️ Ajustes del panel
+          </button>
+        </div>
+        <div className="header-menu__section">
+          <AnnouncementBtn
+            pushToast={pushToast}
+            afterOpen={handleAnnouncement}
+            className="btn btn-sm btn-outline-warning w-100 text-start"
+          />
+        </div>
+        {user && (
+          <div className="header-menu__section">
+            <button type="button" className="header-menu__item" onClick={handleLock}>
+              🔒 Bloquear
+            </button>
+            <button type="button" className="header-menu__item text-danger" onClick={handleLogout}>
+              ⎋ Cerrar sesión
+            </button>
+          </div>
+        )}
+      </div>
+    );
+  };
 
   const nextEventClock = useMemo(() => {
     const ts = tournaments
@@ -398,6 +534,70 @@ const HeaderHUD: React.FC<HeaderHUDProps> = ({
     borderRadius: 14
   };
 
+  const togglePanelMode = () => setSettings(s => ({ ...s, panelMode: s.panelMode === 'simple' ? 'advanced' : 'simple' }));
+
+  if (simpleMode) {
+    return (
+      <header className="sticky-top pt-2 pb-3" style={{zIndex: 1030, background: 'transparent'}}>
+        <div className="container">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="application/json"
+            hidden
+            onChange={e=>{
+              const f=e.target.files?.[0];
+              if(f) importJSON(f);
+              if(fileInputRef.current) fileInputRef.current.value='';
+            }}
+          />
+          <div className="p-3" style={glass}>
+            <div className="d-flex flex-column gap-3">
+              <div className="d-flex align-items-center gap-3 flex-wrap">
+                <div className="d-flex align-items-center gap-3">
+                  <BrandLogo size={44} />
+                  <div className="d-flex flex-column lh-sm">
+                    <strong className="fs-5">SIGAD • TIMMER</strong>
+                    <small className="text-secondary">Modo simple</small>
+                  </div>
+                </div>
+                <div className="ms-auto d-flex flex-wrap align-items-center gap-2">
+                  <span className="badge text-bg-dark" style={{fontVariantNumeric:'tabular-nums'}}>{nowLabel}</span>
+                  <button className="btn btn-sm btn-outline-info" onClick={togglePanelMode} title="Cambiar a modo avanzado">Modo avanzado</button>
+                </div>
+              </div>
+
+              <div className="d-flex flex-wrap gap-2">
+                <button className="btn btn-sm btn-primary" onClick={onNew}>➕ Nuevo</button>
+                <button className="btn btn-sm btn-outline-light" onClick={onOpenItinerary}>🗓 Itinerario</button>
+                <button className="btn btn-sm btn-outline-secondary" onClick={onResetAll}>↺ Reiniciar todos</button>
+                <div className="position-relative">
+                  <button
+                    ref={moreBtnRef}
+                    type="button"
+                    className="btn btn-sm btn-outline-light"
+                    onClick={toggleMore}
+                    aria-haspopup="true"
+                    aria-expanded={moreOpen}
+                  >
+                    ⋯ Opciones
+                  </button>
+                  {renderMoreMenu()}
+                </div>
+              </div>
+
+              <div className="d-flex flex-wrap gap-2 text-secondary small">
+                <span className="badge text-bg-dark">Activos <strong className="ms-1">{runningCount}</strong>/<strong>{total}</strong></span>
+                <span className="badge text-bg-dark">Próximo: <strong className="ms-1">{nextEventClock}</strong></span>
+                <span className="badge text-bg-dark">ETA: <strong className="ms-1">{globalETAClock}</strong></span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </header>
+    );
+  }
+
   const meterDot = (ok:boolean) => (
     <span className={`badge rounded-pill ${ok ? 'text-bg-success' : 'text-bg-secondary'}`} style={{fontVariantNumeric:'tabular-nums'}}>
       ● <span className="ms-1">{ok ? 'Activo' : 'Idle'}</span>
@@ -407,6 +607,17 @@ const HeaderHUD: React.FC<HeaderHUDProps> = ({
   return (
     <header className="sticky-top pt-2 pb-3" style={{zIndex: 1030, background: 'transparent'}}>
       <div className="container">
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="application/json"
+          hidden
+          onChange={e=>{
+            const f=e.target.files?.[0];
+            if(f) importJSON(f);
+            if(fileInputRef.current) fileInputRef.current.value='';
+          }}
+        />
         {/* HUD principal */}
         <div className="p-3" style={glass}>
           <div className="d-flex align-items-center gap-3 flex-wrap">
@@ -441,19 +652,10 @@ const HeaderHUD: React.FC<HeaderHUDProps> = ({
               <div className="vr" />
               <div className="d-flex flex-column align-items-end">
                 <span className="text-secondary small">Ahora</span>
-                <span className="fw-semibold" style={{fontVariantNumeric:'tabular-nums'}}>{now}</span>
+                <span className="fw-semibold" style={{fontVariantNumeric:'tabular-nums'}}>{nowLabel}</span>
               </div>
             </div>
 
-            {/* Sesión */}
-            <div className="ms-xl-3 d-flex align-items-center gap-2 ms-auto">
-              {user && (
-                <div className="btn-group btn-group-sm" role="group" aria-label="Sesion">
-                  <button className="btn btn-outline-warning" onClick={onLock} title="Bloquear">🔒</button>
-                  <button className="btn btn-outline-danger" onClick={onLogout} title="Cerrar sesión">⎋</button>
-                </div>
-              )}
-            </div>
           </div>
 
           {/* Controles: segmentados + acciones */}
@@ -498,29 +700,24 @@ const HeaderHUD: React.FC<HeaderHUDProps> = ({
 
             {/* Acciones rápidas */}
             <div className="vr d-none d-md-block"/>
-            <div className="d-flex flex-wrap gap-2">
-              <button className="btn btn-sm btn-outline-warning" onClick={onPauseAll} title="Pausar todos (P / Space)">⏸ Pausar</button>
-              <button className="btn btn-sm btn-outline-success" onClick={onResumeAll} title="Reanudar todos (R / Space)">▶ Reanudar</button>
-              <button className="btn btn-sm btn-outline-secondary" onClick={onResetAll} title="Resetear todos">↺ Reset</button>
+            <div className="d-flex flex-wrap gap-2 align-items-center">
               <button className="btn btn-sm btn-primary" onClick={onNew} title="Nuevo (N)">➕ Nuevo</button>
-              <button className="btn btn-sm btn-outline-secondary" onClick={onCopySchedule} title="Copiar itinerario">📋 Itinerario</button>
-
-              {/* Importar/Exportar/Ajustes/Anuncio */}
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept="application/json"
-                hidden
-                onChange={e=>{
-                  const f=e.target.files?.[0];
-                  if(f) importJSON(f);
-                  if(fileInputRef.current) fileInputRef.current.value='';
-                }}
-              />
-              <button className="btn btn-sm btn-outline-light" onClick={()=>fileInputRef.current?.click()}>📥 Importar</button>
-              <button className="btn btn-sm btn-outline-light" onClick={onExport}>📤 Exportar</button>
-              <button className="btn btn-sm btn-outline-info" onClick={onOpenSettings} title="Ajustes (S)">⚙️ Ajustes</button>
-              <AnnouncementBtn pushToast={pushToast as any}/>
+              <button className="btn btn-sm btn-outline-light" onClick={onOpenItinerary} title="Abrir itinerario">🗓 Itinerario</button>
+              <button className="btn btn-sm btn-outline-secondary" onClick={onResetAll} title="Reiniciar todos">↺ Reiniciar todos</button>
+              <div className="position-relative">
+                <button
+                  ref={moreBtnRef}
+                  type="button"
+                  className="btn btn-sm btn-outline-light"
+                  onClick={toggleMore}
+                  aria-haspopup="true"
+                  aria-expanded={moreOpen}
+                >
+                  ⋯ Opciones
+                </button>
+                {renderMoreMenu()}
+              </div>
+              <button className="btn btn-sm btn-outline-secondary" onClick={togglePanelMode} title="Cambiar a modo simple">Modo simple</button>
             </div>
 
             {/* Métricas (responsive) */}
@@ -533,6 +730,143 @@ const HeaderHUD: React.FC<HeaderHUDProps> = ({
         </div>
       </div>
     </header>
+  );
+};
+
+type ItineraryDialogProps = {
+  open: boolean;
+  tournaments: Tournament[];
+  timeFmt: TimeFmt;
+  nowMs: number;
+  onClose: () => void;
+  onCopy: () => Promise<void>;
+  pushToast: (t:{kind:any; text:string})=>void;
+};
+
+const ItineraryDialog: React.FC<ItineraryDialogProps> = ({ open, tournaments, timeFmt, nowMs, onClose, onCopy, pushToast }) => {
+  const statusInfo = (t: Tournament) => {
+    const remaining = getRemainingMs(t, nowMs);
+    if (t.timer.running) {
+      if (t.timer.mode === 'break') return { label: 'Descanso en curso', tone: 'info' };
+      return { label: 'Ronda en curso', tone: 'success' };
+    }
+    if (t.timer.target !== null) {
+      if (remaining <= 0) return { label: 'Terminado', tone: 'secondary' };
+      return { label: 'Pausado', tone: 'warning' };
+    }
+    if (t.roundsCompleted >= t.roundsTotal) return { label: 'Finalizado', tone: 'secondary' };
+    return { label: 'Sin iniciar', tone: 'secondary' };
+  };
+
+  const items = useMemo(() => {
+    return tournaments.map(t => {
+      const schedule = computeSchedule(t, timeFmt, nowMs, 0);
+      const eta = computeETAClock(t, timeFmt, nowMs);
+      const { inRound, currentIndex } = computeRoundsInfo(t);
+      const phaseLabel = t.timer.mode === 'break'
+        ? 'Descanso'
+        : inRound
+          ? `Ronda ${currentIndex}`
+          : t.roundsCompleted >= t.roundsTotal
+            ? 'Finalizado'
+            : `Ronda ${Math.min(currentIndex + 1, t.roundsTotal)}`;
+      return {
+        tournament: t,
+        schedule,
+        eta,
+        phaseLabel,
+        status: statusInfo(t),
+      };
+    }).sort((a, b) => {
+      const pri = (x: typeof a) => (x.tournament.timer.running ? 0 : (x.tournament.timer.target ? 1 : 2));
+      const diff = pri(a) - pri(b);
+      if (diff !== 0) return diff;
+      return a.tournament.name.localeCompare(b.tournament.name, 'es');
+    });
+  }, [tournaments, timeFmt, nowMs]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+      if ((e.key === 'c' && (e.metaKey || e.ctrlKey))) {
+        e.preventDefault();
+        onCopy().then(() => {
+          pushToast({ kind: 'success', text: '📋 Itinerario copiado' });
+        }).catch(err => {
+          const msg = err?.message === 'Sin datos' ? 'No hay hitos para copiar' : 'No se pudo copiar el itinerario';
+          pushToast({ kind: 'warning', text: msg });
+        });
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose, onCopy, pushToast]);
+
+  if (!open) return null;
+
+  const copyAndNotify = async () => {
+    try {
+      await onCopy();
+      pushToast({ kind: 'success', text: '📋 Itinerario copiado' });
+    } catch (err: any) {
+      const msg = err?.message === 'Sin datos' ? 'No hay hitos para copiar' : 'No se pudo copiar el itinerario';
+      pushToast({ kind: 'warning', text: msg });
+    }
+  };
+
+  return (
+    <div className="itinerary-overlay" role="dialog" aria-modal="true">
+      <div className="itinerary-backdrop" onClick={onClose} />
+      <div className="itinerary-modal shadow-lg">
+        <div className="itinerary-modal__header">
+          <div>
+            <h2 className="h5 m-0">Itinerario general</h2>
+            <p className="text-secondary mb-0 small">Horas estimadas por torneo y estado actual</p>
+          </div>
+          <div className="d-flex align-items-center gap-2">
+            <button className="btn btn-sm btn-outline-light" onClick={copyAndNotify}>📋 Copiar</button>
+            <button className="btn btn-sm btn-outline-secondary" onClick={onClose}>Cerrar</button>
+          </div>
+        </div>
+        <div className="itinerary-modal__body">
+          {items.length === 0 && (
+            <div className="text-center text-secondary py-4">No hay torneos registrados.</div>
+          )}
+          {items.map(({ tournament, schedule, eta, phaseLabel, status }) => (
+            <article key={tournament.id} className="itinerary-card">
+              <header className="itinerary-card__header">
+                <div>
+                  <h3 className="h6 m-0 text-truncate">{tournament.name}</h3>
+                  <span className="text-secondary small">{tournament.game} • {phaseLabel}</span>
+                </div>
+                <span className={`badge text-bg-${status.tone}`}>{status.label}</span>
+              </header>
+              <div className="itinerary-card__meta">
+                <span>Rondas: {tournament.roundsCompleted}/{tournament.roundsTotal}</span>
+                <span>ETA final: {eta}</span>
+                <span>Auto siguiente: {tournament.autoStartNext ? 'Sí' : 'No'}</span>
+              </div>
+              {schedule.length > 0 ? (
+                <ol className="itinerary-card__list">
+                  {schedule.map((item, idx) => (
+                    <li key={idx}>
+                      <strong>{item.time}</strong>
+                      <span>{item.label}</span>
+                    </li>
+                  ))}
+                </ol>
+              ) : (
+                <div className="itinerary-card__empty text-secondary">Sin eventos programados por el momento.</div>
+              )}
+            </article>
+          ))}
+        </div>
+      </div>
+    </div>
   );
 };
 
@@ -554,7 +888,11 @@ export const MasterPanel: React.FC = () => {
 
   // UI + Ajustes
   const [settings, setSettings] = useState<Settings>(()=> {
-    try { return JSON.parse(localStorage.getItem(LS_UI) || ""); } catch {}
+    try {
+      const raw = localStorage.getItem(LS_UI);
+      if (!raw) return defaultSettings;
+      return parseSettings(JSON.parse(raw));
+    } catch {}
     return defaultSettings;
   });
   useEffect(()=>{ try { localStorage.setItem(LS_UI, JSON.stringify(settings)); } catch{} }, [settings]);
@@ -566,15 +904,12 @@ export const MasterPanel: React.FC = () => {
   // Emitir a DISPLAY (eventos estructurales)
   useEffect(() => { emitAll(tournaments, settings.timeFmt); }, [tournaments, settings.timeFmt]);
 
-  // Reloj visible (texto)
-  const [now, setNow] = useState<string>(()=>dayjs().format(settings.timeFmt==='12'?"ddd DD MMM • hh:mm:ss A":"ddd DD MMM • HH:mm:ss"));
-  useEffect(()=>{
-    const id=setInterval(()=>setNow(dayjs().format(settings.timeFmt==='12'?"ddd DD MMM • hh:mm:ss A":"ddd DD MMM • HH:mm:ss")),1000);
-    return ()=>clearInterval(id);
-  },[settings.timeFmt]);
-
-  // Reloj numérico para timers
-  const nowMs = useClock(250);
+  // Reloj principal (numérico + etiqueta formateada)
+  const nowMs = useClock(1000);
+  const nowLabel = useMemo(
+    () => dayjs(nowMs).format(settings.timeFmt === '12' ? "ddd DD MMM • hh:mm:ss A" : "ddd DD MMM • HH:mm:ss"),
+    [nowMs, settings.timeFmt]
+  );
 
   // Toasts
   const pushToast = useCallback((t: { kind: any; text: string }) => {
@@ -617,7 +952,16 @@ export const MasterPanel: React.FC = () => {
             if (t.autoStartNext && done < t.roundsTotal) {
               if (t.breakEnabled && t.breakMinutes > 0) {
                 const dur = t.breakMinutes * 60_000;
-                next = { ...next, timer: { target: now2 + dur, remainingMs: dur, running: true, label: 'Break', mode: 'break' as TimerMode } };
+                next = {
+                  ...next,
+                  timer: {
+                    target: now2 + dur,
+                    remainingMs: dur,
+                    running: true,
+                    label: 'Descanso',
+                    mode: 'break' as TimerMode,
+                  },
+                };
               } else {
                 const m = t.nextRoundMinutes && t.nextRoundMinutes > 0 ? t.nextRoundMinutes : t.roundMinutes;
                 const dur = m * 60_000;
@@ -679,8 +1023,18 @@ export const MasterPanel: React.FC = () => {
   const startBreakNow = useCallback((id: string) => setTournaments(prev => prev.map(t => {
     if (t.id !== id) return t; if (!t.breakEnabled || t.breakMinutes<=0) return t;
     const now2 = Date.now(); const dur = t.breakMinutes * 60_000;
-    pushToast({ kind:'secondary', text:`☕ ${t.name}: break iniciado (${t.breakMinutes}m)` });
-    return { ...t, warned1m:false, timer: { target: now2 + dur, remainingMs: dur, running: true, label: 'Break', mode:'break' } };
+    pushToast({ kind:'secondary', text:`☕ ${t.name}: descanso iniciado (${t.breakMinutes}m)` });
+    return {
+      ...t,
+      warned1m: false,
+      timer: {
+        target: now2 + dur,
+        remainingMs: dur,
+        running: true,
+        label: 'Descanso',
+        mode: 'break',
+      },
+    };
   })), [pushToast]);
   const skipBreak = useCallback((id: string) => setTournaments(prev => prev.map(t => {
     if (t.id !== id) return t;
@@ -747,6 +1101,7 @@ export const MasterPanel: React.FC = () => {
 
   /* ===== Offcanvas Ajustes ===== */
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [itineraryOpen, setItineraryOpen] = useState(false);
 
   /* ===== CRUD ===== */
   const duplicateTournament = useCallback((id: string) => setTournaments(prev => {
@@ -783,7 +1138,7 @@ export const MasterPanel: React.FC = () => {
           }
           setTournaments(sanitized);
         }
-        if (data.settings) setSettings({ ...defaultSettings, ...data.settings });
+        if (data.settings) setSettings(parseSettings(data.settings));
         pushToast({kind:'success', text:'📥 Importado correctamente'});
       } catch(err) { pushToast({kind:'warning', text:'Error al importar JSON'}); }
     };
@@ -794,24 +1149,26 @@ export const MasterPanel: React.FC = () => {
   const runningCount = tournaments.filter(t => t.timer.running).length;
 
   // Copiar schedule (usar nowMs para precisión)
-  const copySchedule = () => {
-    try {
-      const lines: string[] = [];
-      tournaments.forEach(t => {
-        const sch = computeSchedule(t, settings.timeFmt, nowMs);
-        if (sch.length) {
-          lines.push(`${t.name}:`);
-          sch.forEach(s => lines.push(`  • ${s.label}: ${s.time}`));
-        }
-      });
-      if (!lines.length) { pushToast({kind:'secondary', text:'Nada que copiar'}); return; }
-      navigator.clipboard.writeText(lines.join('\n'));
-      pushToast({kind:'success', text:'📋 Itinerario copiado'});
-    } catch { pushToast({kind:'warning', text:'Error al copiar'}); }
-  };
+  const copySchedule = useCallback(async () => {
+    const lines: string[] = [];
+    tournaments.forEach(t => {
+      const sch = computeSchedule(t, settings.timeFmt, nowMs, 0);
+      if (sch.length) {
+        lines.push(`${t.name}:`);
+        sch.forEach(s => lines.push(`  • ${s.label}: ${s.time}`));
+      }
+    });
+    if (!lines.length) {
+      throw new Error('Sin datos');
+    }
+    await navigator.clipboard.writeText(lines.join('\n'));
+  }, [tournaments, settings.timeFmt, nowMs]);
 
-  const gridClasses = `row g-3 row-cols-1 ${settings.cols===2 ? 'row-cols-xl-2' : ''} ${settings.cols===3 ? 'row-cols-xxl-3' : ''}`.trim();
-  const compact = settings.cols === 3;
+  const showAdvanced = settings.panelMode === 'advanced';
+  const effectiveCols = showAdvanced ? settings.cols : 1;
+  const gridClasses = `row g-3 row-cols-1 ${effectiveCols===2 ? 'row-cols-xl-2' : ''} ${effectiveCols===3 ? 'row-cols-xxl-3' : ''}`.trim();
+  const compact = showAdvanced && effectiveCols === 3;
+  const CardComponent = showAdvanced ? TournamentCard : SimpleTournamentCard;
 
   // Atajos (sin passive:true)
   useEffect(()=>{
@@ -851,23 +1208,24 @@ export const MasterPanel: React.FC = () => {
           aria-hidden
           style={{
             position: 'fixed', inset: 0, pointerEvents: 'none', zIndex: 0,
-            background: `radial-gradient(circle at 30% 20%, rgba(99,102,241,.18), transparent 60%),
-                      radial-gradient(circle at 70% 80%, rgba(236,72,153,.10), transparent 65%)`,
-            opacity: .18,
-            filter: 'saturate(.9) contrast(1.05) brightness(.9)',
-            mixBlendMode: 'luminosity'
+            background: `radial-gradient(circle at 28% 22%, rgba(99,102,241,.24), transparent 62%),
+                      radial-gradient(circle at 72% 78%, rgba(236,72,153,.16), transparent 68%)`,
+            opacity: .24,
+            filter: 'saturate(.95) contrast(1.08) brightness(.92)',
+            mixBlendMode: 'soft-light'
           }}
         >
           <div style={{
             position:'absolute', inset:0, backgroundImage: 'var(--sigad-logo-url)',
-            backgroundRepeat:'no-repeat', backgroundPosition:'center 32%', backgroundSize:'min(56vw, 760px) auto'
+            backgroundRepeat:'no-repeat', backgroundPosition:'center', backgroundSize:'clamp(420px, 60vw, 920px) auto',
+            filter:'blur(.6px) saturate(1.04) brightness(1.02)'
           }} />
         </div>
       )}
 
       {/* ======= HUD Pro (HEADER) ======= */}
       <HeaderHUD
-        now={now}
+        now={nowLabel}
         nowMs={nowMs}
         user={user}
         onLock={lock}
@@ -877,11 +1235,9 @@ export const MasterPanel: React.FC = () => {
         tournaments={tournaments}
         runningCount={runningCount}
         anyRunning={anyRunning}
-        onPauseAll={pauseAll}
-        onResumeAll={resumeAll}
         onResetAll={resetAll}
         onNew={openCreate}
-        onCopySchedule={copySchedule}
+        onOpenItinerary={() => setItineraryOpen(true)}
         onExport={exportJSON}
         onOpenSettings={()=>setSettingsOpen(true)}
         fileInputRef={fileInputRef}
@@ -893,11 +1249,11 @@ export const MasterPanel: React.FC = () => {
       {/* Grid + sidebar preview layout */}
       <main className="container pb-3" style={{maxHeight: 'calc(100vh - 170px)', overflowY: 'auto'}}>
         <div className="row g-3">
-          <div className="col-12 col-xl-9">
+          <div className="col-12 col-xl-8 col-xxl-8">
             <div className={gridClasses}>
               {tournaments.map(t => (
                 <div className="col" key={t.id}>
-                  <TournamentCard
+                  <CardComponent
                     t={t}
                     nowMs={nowMs}
                     timeFmt={settings.timeFmt}
@@ -927,7 +1283,7 @@ export const MasterPanel: React.FC = () => {
               ))}
             </div>
           </div>
-          <div className="col-12 col-xl-3 d-flex flex-column gap-3">
+          <div className="col-12 col-xl-4 col-xxl-4 d-flex flex-column gap-3">
             <DisplayPreview
               tournaments={tournamentsForPreview}
               timeFmt={settings.timeFmt}
@@ -940,6 +1296,15 @@ export const MasterPanel: React.FC = () => {
       {/* Offcanvas & Toasts */}
       <TournamentOffcanvas open={canvasOpen} onClose={closeCanvas} onSubmit={submitCanvas} initial={canvasInitial} />
       <SettingsOffcanvas open={settingsOpen} onClose={()=>setSettingsOpen(false)} value={settings} onChange={(s)=>{ setSettings(s); setSettingsOpen(false); }} />
+      <ItineraryDialog
+        open={itineraryOpen}
+        onClose={() => setItineraryOpen(false)}
+        tournaments={tournaments}
+        timeFmt={settings.timeFmt}
+        nowMs={nowMs}
+        onCopy={copySchedule}
+        pushToast={pushToast}
+      />
       <PanelToastHost position="top-right" />
       <AnnouncementConfigurator />
     </>
@@ -947,9 +1312,9 @@ export const MasterPanel: React.FC = () => {
 };
 
 /* ====================== Tarjeta ====================== */
-const TournamentCard: React.FC<{
+type TournamentCardProps = {
   t: Tournament;
-  nowMs: number;           /* nuevo: usamos nowMs para derivar remaining y progreso */
+  nowMs: number;
   timeFmt: TimeFmt;
   compact?: boolean;
   onEdit: () => void;
@@ -972,7 +1337,179 @@ const TournamentCard: React.FC<{
   duplicate: () => void;
   openDisplay: () => void;
   isDisplayOpen: boolean;
-}> = ({ t, nowMs, timeFmt, compact, onEdit, onChange, startRound, startBreak, skipBreak, pause, resume, reset, add1, add5, sub1, sub5, restartRound, prevRound, completeRound, nextRound, remove, duplicate, openDisplay, isDisplayOpen }) => {
+};
+
+const SimpleTournamentCard: React.FC<TournamentCardProps> = ({ t, nowMs, timeFmt, onEdit, onChange, startRound, startBreak, skipBreak, pause, resume, reset, add1, add5, sub1, sub5, restartRound, prevRound, completeRound, nextRound, remove, duplicate, openDisplay, isDisplayOpen }) => {
+  const { inRound, currentIndex, roundsLeftAfterCurrent } = useMemo(() => computeRoundsInfo(t), [t]);
+  const remainingMs = getRemainingMs(t, nowMs);
+  const expired = !t.timer.running && t.timer.target !== null && remainingMs <= 0;
+  const status = expired ? 'Terminado' : t.timer.running ? 'En curso' : t.timer.target ? 'Pausado' : 'Sin iniciar';
+  const colorCss = COLOR[gameColorKey(t.game)];
+  const schedule = computeSchedule(t, timeFmt, nowMs);
+  const totalSecs = Math.max(0, Math.floor(remainingMs / 1000));
+  const phaseTotalSecs = t.timer.mode === 'break' ? (t.breakMinutes * 60) : (t.roundMinutes * 60);
+  const progress = phaseTotalSecs > 0 ? Math.min(100, Math.max(0, 100 - Math.round((totalSecs / phaseTotalSecs) * 100))) : 0;
+  const eta = computeETAClock(t, timeFmt, nowMs);
+  const quickMinutes = [30,40,45,50,60];
+  const phaseLabel = t.timer.mode === 'break' ? 'Descanso' : inRound ? `Ronda ${currentIndex}` : `Ronda ${Math.min(currentIndex + 1, t.roundsTotal)}`;
+
+  return (
+    <article className="card h-100 bg-body border-0 shadow-sm" style={{borderLeft: `6px solid ${colorCss}`, minWidth: 0}}>
+      <header className="card-header bg-body border-0 py-2" style={{minWidth: 0}}>
+        <div className="d-flex align-items-center gap-2 flex-wrap" style={{minWidth: 0}}>
+          <span className="badge" style={{backgroundColor: colorCss}}>{t.game}</span>
+          <span className="text-secondary small text-truncate" style={{minWidth: 0}}>
+            {phaseLabel} • {t.roundsCompleted}/{t.roundsTotal}
+          </span>
+          <div className="ms-auto d-flex gap-1 flex-wrap">
+            <button className="btn btn-sm btn-outline-light" onClick={onEdit} title="Editar">✎</button>
+            <button className={`btn btn-sm ${isDisplayOpen ? 'btn-secondary' : 'btn-outline-light'}`} onClick={openDisplay} title="Display">🖥</button>
+            <button className="btn btn-sm btn-outline-light" onClick={duplicate} title="Duplicar">⧉</button>
+            <button className="btn btn-sm btn-outline-danger" onClick={remove} title="Eliminar">🗑</button>
+          </div>
+        </div>
+      </header>
+
+      <div className="card-body d-flex flex-column gap-3">
+        <input aria-label="Nombre del torneo" className="form-control form-control-sm fw-semibold" value={t.name} onChange={e=>onChange({ name: e.target.value })} />
+
+        <div className="d-flex flex-wrap gap-2 align-items-center">
+          {t.timer.running ? (
+            <>
+              <button className="btn btn-sm btn-warning px-3" onClick={pause}>⏸ Pausar</button>
+              <div className="btn-group btn-group-sm" role="group">
+                <button className="btn btn-outline-light" onClick={sub5}>−5m</button>
+                <button className="btn btn-outline-light" onClick={sub1}>−1m</button>
+                <button className="btn btn-outline-light" onClick={add1}>+1m</button>
+                <button className="btn btn-outline-light" onClick={add5}>+5m</button>
+              </div>
+            </>
+          ) : !t.timer.running && t.timer.target !== null && remainingMs > 0 ? (
+            <>
+              <button className="btn btn-sm btn-success px-3" onClick={resume}>▶ Reanudar</button>
+              <button className="btn btn-sm btn-outline-light px-3" onClick={reset}>↺ Reset</button>
+            </>
+          ) : (
+            <>
+              <button className="btn btn-sm btn-primary px-3" onClick={()=>startRound()}>▶ Iniciar</button>
+              {t.breakEnabled && t.breakMinutes > 0 && (
+                <button className="btn btn-sm btn-outline-light px-3" onClick={startBreak}>☕ Descanso</button>
+              )}
+              {expired && (
+                <button className="btn btn-sm btn-outline-light px-3" onClick={reset}>↺ Reset</button>
+              )}
+            </>
+          )}
+          {t.timer.mode === 'break' && t.timer.running && (
+            <button className="btn btn-sm btn-outline-light px-3" onClick={skipBreak}>⏭ Omitir descanso</button>
+          )}
+        </div>
+
+        <div className="d-flex flex-wrap align-items-start gap-3">
+          <div className="d-flex flex-column">
+            <span className="text-secondary small">Tiempo restante</span>
+            <span className={`fw-bold ${expired ? 'text-danger' : ''}`} style={{fontVariantNumeric:'tabular-nums', fontSize:'2rem', lineHeight:1.1, color: expired ? undefined : colorCss}}>{format(remainingMs)}</span>
+            <span className="text-secondary small">Estado: {status}</span>
+          </div>
+          <div className="d-flex flex-column">
+            <span className="text-secondary small">Fase actual</span>
+            <span className="fw-semibold">{phaseLabel}</span>
+            <span className="text-secondary small">Objetivo: {t.timer.target ? dayjs(t.timer.target).format(fmtClock(timeFmt)) : '-'}</span>
+          </div>
+          <div className="ms-auto text-end small text-secondary">
+            <div>ETA global: <strong className="ms-1 text-light">{eta}</strong></div>
+            <div>Rondas restantes: {roundsLeftAfterCurrent}</div>
+          </div>
+        </div>
+
+        <div className="progress" role="progressbar" aria-valuenow={progress} aria-valuemin={0} aria-valuemax={100}>
+          <div className="progress-bar" style={{width: `${progress}%`, backgroundColor: colorCss}}></div>
+        </div>
+
+        {schedule.length > 0 && (
+          <div className="d-flex flex-wrap gap-2">
+            {schedule.map((it, i) => (
+              <span key={i} className="badge text-bg-secondary">
+                <span className="me-1">{it.label}:</span>
+                <strong>{it.time}</strong>
+              </span>
+            ))}
+          </div>
+        )}
+
+        <details className="simple-panel__details mt-1">
+          <summary>Controles avanzados</summary>
+          <div className="pt-2 d-flex flex-column gap-3">
+            <div className="row g-2">
+              <div className="col-6">
+                <label className="form-label small mb-1">Rondas totales</label>
+                <input type="number" className="form-control form-control-sm" value={t.roundsTotal} min={1} onChange={e=>onChange({ roundsTotal: Math.max(1, Number(e.target.value)), roundsCompleted: Math.min(t.roundsCompleted, Math.max(1, Number(e.target.value))) })} />
+              </div>
+              <div className="col-6">
+                <label className="form-label small mb-1">Completadas</label>
+                <input type="number" className="form-control form-control-sm" value={t.roundsCompleted} min={0} max={t.roundsTotal} onChange={e=>onChange({ roundsCompleted: Math.min(Math.max(0, Number(e.target.value)), t.roundsTotal) })} />
+              </div>
+              <div className="col-6">
+                <label className="form-label small mb-1">Min/Ronda</label>
+                <input type="number" className="form-control form-control-sm" value={t.roundMinutes} min={1} onChange={e=>onChange({ roundMinutes: Math.max(1, Number(e.target.value)) })} />
+              </div>
+              <div className="col-6">
+                <label className="form-label small mb-1">Min próxima</label>
+                <input type="number" className="form-control form-control-sm" value={t.nextRoundMinutes ?? 0} min={0} onChange={e=>{ const v = Number(e.target.value); onChange({ nextRoundMinutes: v>0 ? v : null }); }} />
+              </div>
+            </div>
+
+            <div className="row g-2">
+              <div className="col-6">
+                <div className="form-check form-switch">
+                  <input className="form-check-input" type="checkbox" id={`simple-break-${t.id}`} checked={t.breakEnabled} onChange={e=>onChange({ breakEnabled: e.target.checked })} />
+                  <label className="form-check-label" htmlFor={`simple-break-${t.id}`}>Descanso habilitado</label>
+                </div>
+              </div>
+              <div className="col-6">
+                <label className="form-label small mb-1">Descanso (min)</label>
+                <input type="number" className="form-control form-control-sm" value={t.breakMinutes} min={0} disabled={!t.breakEnabled} onChange={e=>onChange({ breakMinutes: Math.max(0, Number(e.target.value)) })} />
+              </div>
+            </div>
+
+            <div className="form-check form-switch">
+              <input className="form-check-input" type="checkbox" id={`simple-auto-${t.id}`} checked={t.autoStartNext} onChange={e=>onChange({ autoStartNext: e.target.checked })} />
+              <label className="form-check-label" htmlFor={`simple-auto-${t.id}`}>Auto siguiente</label>
+            </div>
+
+            <div>
+              <label className="form-label small mb-1">Tema del display</label>
+              <select className="form-select form-select-sm" value={t.displayTheme || 'dark'} onChange={e=>onChange({ displayTheme: e.target.value as 'dark'|'light' })}>
+                <option value="dark">Oscuro</option>
+                <option value="light">Luz (claro)</option>
+              </select>
+            </div>
+
+            <div className="d-flex flex-wrap gap-1">
+              {quickMinutes.map(m => (
+                <button key={m} className="btn btn-sm btn-outline-light" onClick={()=>startRound(m, `Ronda rápida (${m}m)`)}>{m}m</button>
+              ))}
+            </div>
+
+            <div className="d-flex flex-wrap gap-2">
+              <button className="btn btn-sm btn-outline-secondary" onClick={restartRound}>⟲ Reiniciar</button>
+              <button className="btn btn-sm btn-outline-secondary" onClick={prevRound} disabled={t.roundsCompleted<=0}>↩ Atrás</button>
+              <button className="btn btn-sm btn-outline-secondary" onClick={completeRound} disabled={t.roundsCompleted >= t.roundsTotal}>✅ Fin</button>
+              <button className="btn btn-sm btn-outline-secondary" onClick={nextRound} disabled={t.roundsCompleted >= t.roundsTotal}>⏭ Sig.</button>
+            </div>
+
+            <div>
+              <label className="form-label small mb-1" htmlFor={`simple-notes-${t.id}`}>Notas</label>
+              <textarea id={`simple-notes-${t.id}`} className="form-control form-control-sm" rows={2} maxLength={2000} value={t.notes || ''} placeholder="Notas del organizador..." onChange={e=>onChange({notes: e.target.value})}></textarea>
+            </div>
+          </div>
+        </details>
+      </div>
+    </article>
+  );
+};
+
+const TournamentCard: React.FC<TournamentCardProps> = ({ t, nowMs, timeFmt, compact, onEdit, onChange, startRound, startBreak, skipBreak, pause, resume, reset, add1, add5, sub1, sub5, restartRound, prevRound, completeRound, nextRound, remove, duplicate, openDisplay, isDisplayOpen }) => {
   const { inRound, currentIndex, roundsLeftAfterCurrent } = useMemo(() => computeRoundsInfo(t), [t]);
   const remainingMs = getRemainingMs(t, nowMs);
   const expired = !t.timer.running && t.timer.target !== null && remainingMs <= 0;
@@ -1000,7 +1537,7 @@ const TournamentCard: React.FC<{
         <div className="d-flex align-items-center gap-2 flex-wrap" style={{ minWidth: 0 }}>
           <span className="badge" style={{backgroundColor: colorCss}}>{t.game}</span>
           <span className="ms-1 text-secondary small text-truncate" style={{ minWidth: 0 }}>
-            {t.timer.mode==='break'? 'Break' : 'Ronda'} • {inRound ? currentIndex : Math.min(currentIndex + 1, t.roundsTotal)} / {t.roundsTotal}
+            {t.timer.mode==='break'? 'Descanso' : 'Ronda'} • {inRound ? currentIndex : Math.min(currentIndex + 1, t.roundsTotal)} / {t.roundsTotal}
           </span>
 
           <div className="ms-auto d-flex gap-1 flex-wrap">
@@ -1014,6 +1551,69 @@ const TournamentCard: React.FC<{
 
       <div className="card-body d-flex flex-column gap-3">
         <input aria-label="Nombre del torneo" className={nameInputClass} value={t.name} onChange={e=>onChange({ name: e.target.value })} />
+
+        <div className="d-flex flex-column gap-2">
+          {(!t.timer.running && t.timer.target === null) && (
+            <>
+              <div className="d-flex flex-wrap gap-2">
+                <button className={`${mainBtn} btn-primary px-4`} onClick={()=>startRound()}>▶ Iniciar</button>
+                {t.breakEnabled && t.breakMinutes>0 && (
+                  <button className={`${mainBtn} btn-outline-light px-4`} onClick={startBreak}>☕ Descanso</button>
+                )}
+              </div>
+              <div className="d-flex flex-wrap gap-1">
+                <div className="btn-group btn-group-sm" role="group" aria-label="Rápido">
+                  {QUICK_MINUTES.map(m=> (
+                    <button key={m} className="btn btn-outline-secondary" onClick={()=>startRound(m, `Ronda rápida (${m}m)`)}>{m}m</button>
+                  ))}
+                </div>
+              </div>
+            </>
+          )}
+
+          {t.timer.running && (
+            <>
+              <div className="d-flex flex-wrap gap-2">
+                <button className={`${mainBtn} btn-warning px-4`} onClick={pause}>⏸ Pausar</button>
+              </div>
+              <div className="btn-group btn-group-sm" role="group">
+                <button className="btn btn-outline-light" onClick={sub5}>−5m</button>
+                <button className="btn btn-outline-light" onClick={sub1}>−1m</button>
+                <button className="btn btn-outline-light" onClick={add1}>+1m</button>
+                <button className="btn btn-outline-light" onClick={add5}>+5m</button>
+              </div>
+            </>
+          )}
+
+          {!t.timer.running && t.timer.target !== null && remainingMs > 0 && (
+            <div className="d-flex flex-wrap gap-2">
+              <button className={`${mainBtn} btn-success px-4`} onClick={resume}>▶ Reanudar</button>
+              <button className={`${mainBtn} btn-outline-light px-4`} onClick={reset}>↺ Reset</button>
+            </div>
+          )}
+
+          {t.timer.mode==='break' && (
+            <div className="d-flex flex-wrap gap-2">
+              <button className={`${mainBtn} btn-secondary px-4`} onClick={skipBreak}>⏭ Omitir descanso</button>
+            </div>
+          )}
+
+          <details className="card-advanced-actions">
+            <summary className="small text-secondary pointer">Más opciones</summary>
+            <div className="pt-2 d-flex flex-wrap gap-2">
+              <button className={`${smallBtn} btn-outline-light`} onClick={restartRound}>⟲ Reiniciar</button>
+              <button className={`${smallBtn} btn-secondary`} onClick={prevRound} disabled={t.roundsCompleted<=0}>↩ Atrás</button>
+              <button className={`${smallBtn} btn-secondary`} onClick={completeRound} disabled={t.roundsCompleted >= t.roundsTotal}>✅ Fin</button>
+              <button className={`${smallBtn} btn-dark border`} onClick={nextRound} disabled={t.roundsCompleted >= t.roundsTotal}>⏭ Sig.</button>
+              <button className={`${smallBtn} btn-outline-secondary`} onClick={()=>{
+                const inp = prompt('Minutos nuevos (reemplaza el timer actual):');
+                if (!inp) return; const v = Number(inp);
+                if (!Number.isFinite(v) || v<=0) return;
+                startRound(v, v+ 'm manual');
+              }}>✎ Set</button>
+            </div>
+          </details>
+        </div>
 
         {/* Stats */}
         <div className="row g-2 align-items-end">
@@ -1034,7 +1634,7 @@ const TournamentCard: React.FC<{
           </div>
           <div className={colStat}>
             <div className="text-secondary small">Fase</div>
-            <div className="fw-bold">{t.timer.mode==='break' ? 'Break' : inRound ? `Ronda ${currentIndex}` : `Ronda ${Math.min(currentIndex+1, t.roundsTotal)}`}</div>
+            <div className="fw-bold">{t.timer.mode==='break' ? 'Descanso' : inRound ? `Ronda ${currentIndex}` : `Ronda ${Math.min(currentIndex+1, t.roundsTotal)}`}</div>
             <div className="text-secondary small">{t.autoStartNext ? 'Auto siguiente: Sí' : 'Auto siguiente: No'}</div>
           </div>
         </div>
@@ -1067,11 +1667,11 @@ const TournamentCard: React.FC<{
           <div className={colHalf}>
             <div className="form-check form-switch">
               <input className="form-check-input" type="checkbox" id={`break-${t.id}`} checked={t.breakEnabled} onChange={e=>onChange({ breakEnabled: e.target.checked })} />
-              <label className="form-check-label" htmlFor={`break-${t.id}`}>Habilitar break</label>
+              <label className="form-check-label" htmlFor={`break-${t.id}`}>Habilitar descanso</label>
             </div>
           </div>
           <div className="col-6 col-sm-3">
-            <label className="form-label small mb-1">Break (min)</label>
+            <label className="form-label small mb-1">Descanso (min)</label>
             <input type="number" className="form-control" value={t.breakMinutes} min={0} disabled={!t.breakEnabled}
                    onChange={e=>onChange({ breakMinutes: Math.max(0, Number(e.target.value)) })} />
           </div>
@@ -1115,71 +1715,6 @@ const TournamentCard: React.FC<{
           <textarea className="form-control mt-1" rows={3} maxLength={2000} value={t.notes || ''} placeholder="Notas del organizador..." onChange={e=>onChange({notes: e.target.value})}></textarea>
         </details>
 
-        {/* ===== Controles prioritarios en GRANDE ===== */}
-        <div className="mt-auto d-flex flex-column gap-2">
-          {/* Estado: sin iniciar */}
-          {(!t.timer.running && t.timer.target === null) && (
-            <>
-              <div className="d-flex flex-wrap gap-2">
-                <button className={`${mainBtn} btn-primary px-4`} onClick={()=>startRound()}>▶ Iniciar</button>
-                {t.breakEnabled && t.breakMinutes>0 && (
-                  <button className={`${mainBtn} btn-outline-light px-4`} onClick={startBreak}>☕ Break</button>
-                )}
-              </div>
-              <div className="d-flex flex-wrap gap-1">
-                <div className="btn-group btn-group-sm" role="group" aria-label="Rápido">
-                  {[30,40,45,50,60].map(m=> (
-                    <button key={m} className="btn btn-outline-secondary" onClick={()=>startRound(m, `Ronda rápida (${m}m)`)}>{m}m</button>
-                  ))}
-                </div>
-              </div>
-            </>
-          )}
-
-          {/* Estado: corriendo */}
-          {t.timer.running && (
-            <>
-              <div className="d-flex flex-wrap gap-2">
-                <button className={`${mainBtn} btn-warning px-4`} onClick={pause}>⏸ Pausar</button>
-              </div>
-              <div className="btn-group btn-group-sm" role="group">
-                <button className="btn btn-outline-light" onClick={sub5}>−5m</button>
-                <button className="btn btn-outline-light" onClick={sub1}>−1m</button>
-                <button className="btn btn-outline-light" onClick={add1}>+1m</button>
-                <button className="btn btn-outline-light" onClick={add5}>+5m</button>
-              </div>
-            </>
-          )}
-
-          {/* Estado: pausado */}
-          {!t.timer.running && t.timer.target !== null && remainingMs > 0 && (
-            <div className="d-flex flex-wrap gap-2">
-              <button className={`${mainBtn} btn-success px-4`} onClick={resume}>▶ Reanudar</button>
-              <button className={`${mainBtn} btn-outline-light px-4`} onClick={reset}>↺ Reset</button>
-            </div>
-          )}
-
-          {/* En break */}
-          {t.timer.mode==='break' && (
-            <div className="d-flex flex-wrap gap-2">
-              <button className={`${mainBtn} btn-secondary px-4`} onClick={skipBreak}>⏭ Omitir break</button>
-            </div>
-          )}
-
-          {/* Acciones secundarias */}
-          <div className="d-flex flex-wrap gap-2 justify-content-end">
-            <button className={`${smallBtn} btn-outline-light`} onClick={restartRound}>⟲ Reiniciar</button>
-            <button className={`${smallBtn} btn-secondary`} onClick={prevRound} disabled={t.roundsCompleted<=0}>↩ Atrás</button>
-            <button className={`${smallBtn} btn-secondary`} onClick={completeRound} disabled={t.roundsCompleted >= t.roundsTotal}>✅ Fin</button>
-            <button className={`${smallBtn} btn-dark border`} onClick={nextRound} disabled={t.roundsCompleted >= t.roundsTotal}>⏭ Sig.</button>
-            <button className={`${smallBtn} btn-outline-secondary`} onClick={()=>{
-              const inp = prompt('Minutos nuevos (reemplaza el timer actual):');
-              if (!inp) return; const v = Number(inp);
-              if (!Number.isFinite(v) || v<=0) return;
-              startRound(v, v+ 'm manual');
-            }}>✎ Set</button>
-          </div>
-        </div>
       </div>
     </article>
   );
@@ -1199,9 +1734,20 @@ const defaultAnnouncement: AnnouncementDraft = { text: '', kind: 'info', duratio
 // Estado global simple (ref) para abrir configurador desde botón
 const announcementState: { open: boolean; setOpen?: (v:boolean)=>void; submit?: (d:AnnouncementDraft)=>void; draft: AnnouncementDraft } = { open:false, draft: defaultAnnouncement };
 
-const AnnouncementButton: React.FC<{ pushToast: (t: {kind:any; text:string; icon?:string})=>void }> = () => {
+const AnnouncementButton: React.FC<{ pushToast: (t: {kind:any; text:string; icon?:string})=>void; afterOpen?: ()=>void; className?: string }> = ({ afterOpen, className }) => {
+  const cls = className ?? "btn btn-sm btn-outline-warning";
   return (
-    <button className="btn btn-sm btn-outline-warning" onClick={()=>{ announcementState.open = true; announcementState.setOpen?.(true); }} title="Anuncio público avanzado (A)">📢 Anunciar</button>
+    <button
+      className={cls}
+      onClick={() => {
+        announcementState.open = true;
+        announcementState.setOpen?.(true);
+        afterOpen?.();
+      }}
+      title="Anuncio público avanzado (A)"
+    >
+      📢 Anunciar
+    </button>
   );
 };
 

--- a/src/BrandLogo.tsx
+++ b/src/BrandLogo.tsx
@@ -15,7 +15,7 @@ export const BrandLogo: React.FC<{ size?: number; alt?: string; className?: stri
     opacity:.22, filter:'blur(10px)', mixBlendMode:'color-dodge'
   };
   const img: React.CSSProperties = {
-    position:'absolute', inset: `${Math.round(px*0.18)}px`, backgroundImage:'var(--sigad-logo-url)', backgroundRepeat:'no-repeat',
+    position:'absolute', inset: `${Math.round(px*0.14)}px`, backgroundImage:'var(--sigad-logo-url)', backgroundRepeat:'no-repeat',
     backgroundPosition:'center', backgroundSize:'contain', filter:'drop-shadow(0 2px 4px rgba(0,0,0,.6)) saturate(1.05) brightness(1.02)'
   } as React.CSSProperties;
   const fallback: React.CSSProperties = {

--- a/src/DisplayPreview.tsx
+++ b/src/DisplayPreview.tsx
@@ -2,6 +2,12 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { emitAll, type TimeFmt } from './displayChannel';
 import type { Tournament } from './App';
 
+type HudDensity = 'compact' | 'standard' | 'expanded';
+const HUD_DENSITIES: HudDensity[] = ['compact', 'standard', 'expanded'];
+const HUD_DENSITY_KEY_GLOBAL = 'sigad-hud-density';
+const HUD_SCALE_KEY_GLOBAL = 'sigad-hud-scale';
+const ZOOM_PRESETS = [70, 85, 100, 115, 130, 140];
+
 /**
  * DisplayPreview • v4.2
  * - Prioriza torneos corriendo (max 3).
@@ -50,6 +56,14 @@ export const DisplayPreview: React.FC<{
   const LS_FIT = 'sigad_preview_fit_v1';
   const [fitMap, setFitMap] = useState<Record<string, 'contain'|'width'|'height'>>(() => readObj(LS_FIT));
 
+  // HUD density
+  const LS_DENSITY = 'sigad_preview_density_v1';
+  const [densityMap, setDensityMap] = useState<Record<string, HudDensity>>(() => readObj(LS_DENSITY));
+
+  // HUD scale
+  const LS_SCALE = 'sigad_preview_scale_v1';
+  const [scaleMap, setScaleMap] = useState<Record<string, number>>(() => readObj(LS_SCALE));
+
   // Overlay heights
   const LS_H_EXP = 'sigad_preview_h_exp_v1';
   const [expHeights, setExpHeights] = useState<Record<string, number>>(() => readObj(LS_H_EXP));
@@ -59,6 +73,8 @@ export const DisplayPreview: React.FC<{
   useEffect(() => { try { localStorage.setItem(LS_H, JSON.stringify(heights)); } catch {} }, [heights]);
   useEffect(() => { try { localStorage.setItem(LS_FX, JSON.stringify(fxMap)); } catch {} }, [fxMap]);
   useEffect(() => { try { localStorage.setItem(LS_FIT, JSON.stringify(fitMap)); } catch {} }, [fitMap]);
+  useEffect(() => { try { localStorage.setItem(LS_DENSITY, JSON.stringify(densityMap)); } catch {} }, [densityMap]);
+  useEffect(() => { try { localStorage.setItem(LS_SCALE, JSON.stringify(scaleMap)); } catch {} }, [scaleMap]);
   useEffect(() => { try { localStorage.setItem(LS_H_EXP, JSON.stringify(expHeights)); } catch {} }, [expHeights]);
 
   const getH     = (id: string) => clampSidebarH(heights[id] ?? DEFAULT_H);
@@ -66,11 +82,57 @@ export const DisplayPreview: React.FC<{
   const isFxOn   = (id: string) => fxMap[id] !== false; // por defecto ON
   const toggleFx = (id: string) => setFxMap(prev => ({ ...prev, [id]: !(prev[id] !== false) }));
   const getFit   = (id: string) => (fitMap[id] ?? 'contain') as 'contain'|'width'|'height';
+  const setFitMode = (id: string, mode: 'contain'|'width'|'height') => setFitMap(prev => ({ ...prev, [id]: mode }));
   const cycleFit = (id: string) => setFitMap(prev => {
     const cur = (prev[id] ?? 'contain') as 'contain'|'width'|'height';
     const next = cur === 'contain' ? 'width' : cur === 'width' ? 'height' : 'contain';
     return { ...prev, [id]: next };
   });
+  const pushDensity = (id: string, mode: HudDensity) => {
+    const origin = typeof window !== 'undefined' ? window.location.origin : '*';
+    const targetOrigin = origin || '*';
+    const frame = document.getElementById(`prev-${id}`) as HTMLIFrameElement | null;
+    frame?.contentWindow?.postMessage({ type: 'HUD_DENSITY', value: mode }, targetOrigin);
+    const expanded = document.getElementById(`prev-exp-${id}`) as HTMLIFrameElement | null;
+    expanded?.contentWindow?.postMessage({ type: 'HUD_DENSITY', value: mode }, targetOrigin);
+    try { localStorage.setItem(HUD_DENSITY_KEY_GLOBAL, mode); } catch {}
+  };
+  const pushScale = (id: string, value: number) => {
+    const origin = typeof window !== 'undefined' ? window.location.origin : '*';
+    const targetOrigin = origin || '*';
+    const frame = document.getElementById(`prev-${id}`) as HTMLIFrameElement | null;
+    frame?.contentWindow?.postMessage({ type: 'HUD_SCALE', value }, targetOrigin);
+    const expanded = document.getElementById(`prev-exp-${id}`) as HTMLIFrameElement | null;
+    expanded?.contentWindow?.postMessage({ type: 'HUD_SCALE', value }, targetOrigin);
+    try { localStorage.setItem(HUD_SCALE_KEY_GLOBAL, String(value)); } catch {}
+  };
+  const getDensity = (id: string): HudDensity => (densityMap[id] as HudDensity) ?? 'standard';
+  const setDensity = (id: string, mode: HudDensity) => setDensityMap(prev => ({ ...prev, [id]: mode }));
+  const applyDensity = (id: string, mode: HudDensity) => {
+    setDensity(id, mode);
+    pushDensity(id, mode);
+  };
+  const cycleDensityMode = (id: string) => {
+    const current = getDensity(id);
+    const idx = HUD_DENSITIES.indexOf(current);
+    const next = HUD_DENSITIES[(idx + 1) % HUD_DENSITIES.length];
+    applyDensity(id, next);
+  };
+  const densityLabel = (mode: HudDensity) => (mode === 'compact' ? 'Compacto' : mode === 'expanded' ? 'Amplio' : 'Equilibrado');
+  const clampScalePct = (v: number) => Math.max(70, Math.min(140, Math.round(v)));
+  const getScale = (id: string) => clampScalePct(scaleMap[id] ?? 100);
+  const updateScale = (id: string, value: number) => {
+    const next = clampScalePct(value);
+    setScaleMap(prev => {
+      if (prev[id] === next) return prev;
+      return { ...prev, [id]: next };
+    });
+    pushScale(id, next);
+  };
+  const nudgeScale = (id: string, delta: number) => {
+    const current = getScale(id);
+    updateScale(id, current + delta);
+  };
   const getExpH  = (id: string) => clampOverlayH(expHeights[id] ?? DEFAULT_H_EXP);
   const setExpH  = (id: string, v: number) => setExpHeights(prev => ({ ...prev, [id]: clampOverlayH(v) }));
 
@@ -83,7 +145,7 @@ export const DisplayPreview: React.FC<{
   /* ---------- TICK local para HUD (countdown vivo) ---------- */
   const [, setTick] = useState(0);
   useEffect(() => {
-    const id = setInterval(() => setTick(v => (v+1)%1_000_000), 500); // 2 Hz
+    const id = setInterval(() => setTick(v => (v+1)%1_000_000), 1000);
     return () => clearInterval(id);
   }, []);
 
@@ -131,6 +193,11 @@ export const DisplayPreview: React.FC<{
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const overlayDragRef = useRef<{ startY: number; startH: number } | null>(null);
   const [overlayDragging, setOverlayDragging] = useState(false);
+  const [hudMenuFor, setHudMenuFor] = useState<string | null>(null);
+  const hudMenuRef = useRef<HTMLDivElement | null>(null);
+  const hudButtonRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+  const toggleHudMenu = (id: string) => setHudMenuFor(prev => (prev === id ? null : id));
+  const closeHudMenu = () => setHudMenuFor(null);
   const onOverlayMove = (e: PointerEvent) => {
     if (!overlayDragRef.current || !expandedId) return;
     const dy = e.clientY - overlayDragRef.current.startY;
@@ -162,6 +229,30 @@ export const DisplayPreview: React.FC<{
     return () => window.removeEventListener('keydown', onKey);
   }, [expandedId]);
 
+  useEffect(() => {
+    if (!hudMenuFor) {
+      hudMenuRef.current = null;
+      return;
+    }
+    const onPointer = (e: PointerEvent) => {
+      const menuEl = hudMenuRef.current;
+      const btnEl = hudButtonRefs.current[hudMenuFor];
+      const target = e.target as Node | null;
+      if (menuEl && menuEl.contains(target)) return;
+      if (btnEl && btnEl.contains(target)) return;
+      setHudMenuFor(null);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setHudMenuFor(null);
+    };
+    window.addEventListener('pointerdown', onPointer);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('pointerdown', onPointer);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [hudMenuFor]);
+
   /* ---------- Medición de ancho por tarjeta (ResizeObserver) ---------- */
   const [boxW, setBoxW] = useState<Record<string, number>>({});
   const observersRef = useRef<Record<string, ResizeObserver | null>>({});
@@ -191,11 +282,22 @@ export const DisplayPreview: React.FC<{
 
   /* ---------- Carga/estado de iframes ---------- */
   const [loaded, setLoaded] = useState<Record<string, boolean>>({});
-  const markLoaded = (id: string) => setLoaded(prev => ({ ...prev, [id]: true }));
+  const markLoaded = (id: string) => {
+    setLoaded(prev => ({ ...prev, [id]: true }));
+    pushDensity(id, getDensity(id));
+    pushScale(id, getScale(id));
+  };
+  const frameIdToTournamentId = (frameId: string) => {
+    if (frameId.startsWith('prev-exp-')) return frameId.slice('prev-exp-'.length);
+    if (frameId.startsWith('prev-')) return frameId.slice('prev-'.length);
+    return frameId;
+  };
+
   const reloadFrame = (id: string) => {
     const iframe = document.getElementById(id) as HTMLIFrameElement | null;
     if (!iframe) return;
-    setLoaded(prev => ({ ...prev, [id.replace('prev-', '').replace('prev-exp-', '')]: false }));
+    const key = frameIdToTournamentId(id);
+    setLoaded(prev => ({ ...prev, [key]: false }));
     const s = iframe.src;
     iframe.src = 'about:blank';
     setTimeout(() => { iframe.src = s; }, 30);
@@ -230,7 +332,7 @@ export const DisplayPreview: React.FC<{
     const inRound = t.timer.mode === 'round' && (t.timer.running || t.timer.remainingMs > 0);
     const roundIdx = inRound ? t.roundsCompleted + 1 : t.roundsCompleted;
     const phase =
-      t.timer.mode === 'break' ? 'Break'
+      t.timer.mode === 'break' ? 'Descanso'
       : `Ronda ${Math.max(1, Math.min(roundIdx || 1, t.roundsTotal))}/${t.roundsTotal}`;
     return { state, color, remaining: rem, remainingFmt: formatSplit(rem), phase };
   };
@@ -260,8 +362,11 @@ export const DisplayPreview: React.FC<{
         {sorted.map(t => {
           const hNow = getH(t.id);
           const fit = getFit(t.id);
+          const density = getDensity(t.id);
+          const hudScale = getScale(t.id);
           const themeParam = (t.displayTheme || 'dark') === 'light' ? '&theme=light' : '';
-          const url = `/display.html?id=${encodeURIComponent(t.id)}${isFxOn(t.id) ? '' : '&nofx=1'}${themeParam}`;
+          const baseUrl = `/display.html?id=${encodeURIComponent(t.id)}${isFxOn(t.id) ? '' : '&nofx=1'}${themeParam}`;
+          const windowUrl = `${baseUrl}&hud=${density}&scale=${hudScale}`;
 
           // Medición de ancho disponible:
           const availW = Math.max(240, (boxW[t.id] ?? 0) || 0);
@@ -270,16 +375,21 @@ export const DisplayPreview: React.FC<{
           const sH = Math.max(0.1, hNow / baseH);
           const sW = Math.max(0.1, availW / baseW);
           const raw = fit === 'height' ? sH : fit === 'width' ? sW : Math.min(sH, sW);
-          const scale = snapScale(raw);
+          const previewScale = snapScale(raw);
 
-          const frameW = Math.round(baseW * scale);
-          const frameH = Math.round(baseH * scale);
-          const scalePct = Math.round(scale * 100);
+          const frameW = Math.round(baseW * previewScale);
+          const frameH = Math.round(baseH * previewScale);
+          const previewScalePct = Math.round(previewScale * 100);
 
           const { state, color, remainingFmt, phase } = stateInfo(t);
+          const wantsHudMenu = hudMenuFor === t.id;
+          const showHudMenuHere = wantsHudMenu && expandedId !== t.id;
+          const hudButtonActive = wantsHudMenu;
+          const densityName = densityLabel(density);
+          const fitLabel = fit === 'contain' ? 'Contener' : fit === 'width' ? 'Ancho' : 'Alto';
 
           return (
-            <div key={t.id} className="card bg-body border-0 shadow-sm" style={{ overflow: 'hidden' }}>
+            <div key={t.id} className="card bg-body border-0 shadow-sm" style={{ overflow: 'visible' }}>
               {/* ===== Header con grupos ===== */}
               <div className="card-header bg-body border-0 py-2">
                 <div className="d-flex align-items-center gap-2 flex-wrap">
@@ -287,53 +397,176 @@ export const DisplayPreview: React.FC<{
                   <span className="badge text-bg-secondary">{t.game}</span>
 
                   <div className="ms-auto d-flex align-items-center flex-wrap gap-2">
-                    {/* Grupo 1: Ajuste + Expandir */}
-                    <div className="btn-group btn-group-sm" role="group" aria-label="Ajuste y expandir">
-                      <button
-                        className="btn btn-outline-light"
-                        onClick={() => cycleFit(t.id)}
-                        title={`Ajuste: ${fit === 'contain' ? 'Contener' : fit === 'width' ? 'Ajustar al ancho' : 'Ajustar al alto'}`}
-                        aria-label="Cambiar modo de ajuste"
-                      >
-                        {fit === 'contain' ? '⤧' : fit === 'width' ? '⇔' : '⇕'}
-                        <span className="d-none d-md-inline ms-1">
-                          {fit === 'contain' ? 'Contain' : fit === 'width' ? 'Ancho' : 'Alto'}
-                        </span>
-                      </button>
-                      <button className="btn btn-primary" onClick={() => setExpandedId(t.id)} title="Expandir preview">
-                        ⤢ <span className="d-none d-md-inline ms-1">Expandir</span>
-                      </button>
+                    {/* Grupo 1: Ajuste + HUD + Expandir */}
+                    <div className="position-relative">
+                      <div className="d-flex align-items-center gap-2">
+                        <span className="badge text-bg-dark d-none d-md-inline">{fitLabel}</span>
+                        <div className="btn-group btn-group-sm" role="group" aria-label="HUD y expansión">
+                          <button
+                            className={hudButtonActive ? 'btn btn-light' : 'btn btn-outline-light'}
+                            onClick={() => toggleHudMenu(t.id)}
+                            ref={el => { hudButtonRefs.current[t.id] = el; }}
+                            title={`Zoom HUD: ${hudScale}% · ${densityName}`}
+                            aria-expanded={hudButtonActive}
+                            aria-controls={`hud-menu-${t.id}`}
+                          >
+                            {density === 'compact' ? '▣' : density === 'expanded' ? '▢' : '▤'}
+                            <span className="d-none d-md-inline ms-1">HUD</span>
+                          </button>
+                          <button className="btn btn-primary" onClick={() => setExpandedId(t.id)} title="Expandir preview">
+                            ⤢ <span className="d-none d-md-inline ms-1">Expandir</span>
+                          </button>
+                        </div>
+                      </div>
+                      <div className="btn-group btn-group-sm ms-2" role="group" aria-label="Zoom del HUD">
+                        <button
+                          type="button"
+                          className="btn btn-outline-light"
+                          onClick={() => nudgeScale(t.id, -5)}
+                          title="Reducir zoom del HUD"
+                          aria-label="Reducir zoom del HUD"
+                        >
+                          −
+                        </button>
+                        <button
+                          type="button"
+                          className="btn btn-outline-light"
+                          onClick={() => nudgeScale(t.id, 5)}
+                          title="Ampliar zoom del HUD"
+                          aria-label="Ampliar zoom del HUD"
+                        >
+                          +
+                        </button>
+                      </div>
+                      {showHudMenuHere && (
+                        <div
+                          id={`hud-menu-${t.id}`}
+                          ref={el => { if (showHudMenuHere) hudMenuRef.current = el; }}
+                          className="hud-config-menu shadow"
+                          role="dialog"
+                          aria-label="Opciones de HUD"
+                        >
+                          <div className="hud-config-menu__section">
+                            <div className="hud-config-menu__label">Ajuste</div>
+                            <div className="btn-group btn-group-sm w-100" role="group" aria-label="Modo de ajuste">
+                              <button
+                                type="button"
+                                className={`btn ${fit === 'contain' ? 'btn-secondary' : 'btn-outline-secondary'}`}
+                                onClick={() => setFitMode(t.id, 'contain')}
+                              >
+                                Contener
+                              </button>
+                              <button
+                                type="button"
+                                className={`btn ${fit === 'width' ? 'btn-secondary' : 'btn-outline-secondary'}`}
+                                onClick={() => setFitMode(t.id, 'width')}
+                              >
+                                Ancho
+                              </button>
+                              <button
+                                type="button"
+                                className={`btn ${fit === 'height' ? 'btn-secondary' : 'btn-outline-secondary'}`}
+                                onClick={() => setFitMode(t.id, 'height')}
+                              >
+                                Alto
+                              </button>
+                            </div>
+                          </div>
+                          <div className="hud-config-menu__section">
+                            <div className="hud-config-menu__label">Tema y efectos</div>
+                            <div className="btn-group btn-group-sm w-100" role="group" aria-label="Tema y efectos">
+                              <button
+                                type="button"
+                                className={`btn ${(t.displayTheme || 'dark') === 'light' ? 'btn-warning' : 'btn-outline-warning'}`}
+                                onClick={() => onToggleTheme(t.id)}
+                              >
+                                {(t.displayTheme || 'dark') === 'light' ? '🌞 Claro' : '🌙 Oscuro'}
+                              </button>
+                              <button
+                                type="button"
+                                className={`btn ${isFxOn(t.id) ? 'btn-outline-warning' : 'btn-warning'}`}
+                                onClick={() => toggleFx(t.id)}
+                              >
+                                {isFxOn(t.id) ? '✨ FX activos' : '🚫 Sin FX'}
+                              </button>
+                            </div>
+                          </div>
+                          <div className="hud-config-menu__section">
+                            <div className="hud-config-menu__label">Densidad</div>
+                            <div className="btn-group btn-group-sm w-100" role="group" aria-label="Modo de densidad">
+                              <button
+                                type="button"
+                                className={`btn ${density === 'compact' ? 'btn-secondary' : 'btn-outline-secondary'}`}
+                                onClick={() => applyDensity(t.id, 'compact')}
+                              >
+                                Compacto
+                              </button>
+                              <button
+                                type="button"
+                                className={`btn ${density === 'standard' ? 'btn-secondary' : 'btn-outline-secondary'}`}
+                                onClick={() => applyDensity(t.id, 'standard')}
+                              >
+                                Equilibrado
+                              </button>
+                              <button
+                                type="button"
+                                className={`btn ${density === 'expanded' ? 'btn-secondary' : 'btn-outline-secondary'}`}
+                                onClick={() => applyDensity(t.id, 'expanded')}
+                              >
+                                Amplio
+                              </button>
+                            </div>
+                          </div>
+                          <div className="hud-config-menu__section">
+                            <div className="hud-config-menu__label d-flex justify-content-between align-items-center">
+                              <span>Zoom del HUD</span>
+                              <span className="badge text-bg-secondary">{hudScale}%</span>
+                            </div>
+                            <input
+                              type="range"
+                              min={70}
+                              max={140}
+                              step={5}
+                              value={hudScale}
+                              onChange={e => updateScale(t.id, Number(e.target.value))}
+                              className="form-range hud-config-menu__slider"
+                              aria-label="Zoom del HUD"
+                            />
+                            <div className="d-flex justify-content-between text-muted small">
+                              <span>Menos zoom</span>
+                              <span>Más zoom</span>
+                            </div>
+                            <div className="d-flex flex-wrap gap-2 mt-2">
+                              {ZOOM_PRESETS.map(val => (
+                                <button
+                                  key={val}
+                                  type="button"
+                                  className={`btn btn-sm ${hudScale === val ? 'btn-secondary' : 'btn-outline-secondary'}`}
+                                  onClick={() => updateScale(t.id, val)}
+                                >
+                                  {val}%
+                                </button>
+                              ))}
+                            </div>
+                          </div>
+                          <button
+                            type="button"
+                            className="btn btn-link p-0 small text-decoration-none"
+                            onClick={closeHudMenu}
+                          >
+                            Cerrar
+                          </button>
+                        </div>
+                      )}
                     </div>
 
                     <div className="toolbar-sep d-none d-sm-block" aria-hidden />
 
-                    {/* Grupo 2: Tema + FX */}
-                    <div className="btn-group btn-group-sm" role="group" aria-label="Tema y efectos">
-                      <button
-                        className={(t.displayTheme || 'dark') === 'light' ? 'btn btn-warning' : 'btn btn-outline-warning'}
-                        onClick={() => onToggleTheme(t.id)}
-                        title="Alternar tema del display (claro/oscuro)"
-                      >
-                        {(t.displayTheme || 'dark') === 'light' ? '🌞' : '🌙'}
-                        <span className="d-none d-md-inline ms-1">Tema</span>
-                      </button>
-                      <button
-                        className={isFxOn(t.id) ? 'btn btn-outline-warning' : 'btn btn-warning'}
-                        onClick={() => toggleFx(t.id)}
-                        title={isFxOn(t.id) ? 'Desactivar efectos' : 'Activar efectos'}
-                      >
-                        {isFxOn(t.id) ? '✨' : '🚫'}
-                        <span className="d-none d-md-inline ms-1">FX</span>
-                      </button>
-                    </div>
-
-                    <div className="toolbar-sep d-none d-sm-block" aria-hidden />
-
-                    {/* Grupo 3: Ventana + Recargar */}
+                    {/* Grupo Ventana + Recargar */}
                     <div className="btn-group btn-group-sm" role="group" aria-label="Ventana y recargar">
                       <a
                         className="btn btn-outline-light"
-                        href={url}
+                        href={windowUrl}
                         target={`SIGAD_DISPLAY_${t.id}`}
                         rel="noreferrer"
                         title="Abrir en ventana"
@@ -462,14 +695,14 @@ export const DisplayPreview: React.FC<{
                     {/* IFRAME */}
                     <iframe
                       id={`prev-${t.id}`}
-                      src={url}
+                      src={baseUrl}
                       title={`preview-${t.name}`}
                       onLoad={() => markLoaded(t.id)}
                       style={{
                         width: baseW,
                         height: baseH,
                         border: 0,
-                        transform: `scale(${scale}) translateZ(0)`,
+                        transform: `scale(${previewScale}) translateZ(0)`,
                         transformOrigin: 'top left',
                         willChange: 'transform',
                         background: 'transparent'
@@ -493,8 +726,9 @@ export const DisplayPreview: React.FC<{
                         zIndex: 2
                       }}
                     >
-                      <span>{scalePct}%</span>
-                      <span style={{ opacity: 0.85 }}>{fit}</span>
+                      <span>Vista {previewScalePct}%</span>
+                      <span style={{ opacity: 0.85 }}>{fitLabel}</span>
+                      <span style={{ opacity: 0.7 }}>Zoom {hudScale}% · {densityName}</span>
                     </div>
                   </div>
                 </div>
@@ -530,8 +764,12 @@ export const DisplayPreview: React.FC<{
         const t = tournaments.find(x => x.id === expandedId);
         if (!t) return null;
         const fit = getFit(t.id);
+        const density = getDensity(t.id);
+        const hudScale = getScale(t.id);
+        const densityName = densityLabel(density);
         const themeParam = (t.displayTheme || 'dark') === 'light' ? '&theme=light' : '';
-        const url = `/display.html?id=${encodeURIComponent(t.id)}${isFxOn(t.id) ? '' : '&nofx=1'}${themeParam}`;
+        const baseUrl = `/display.html?id=${encodeURIComponent(t.id)}${isFxOn(t.id) ? '' : '&nofx=1'}${themeParam}`;
+        const windowUrl = `${baseUrl}&hud=${density}&scale=${hudScale}`;
 
         // Dimensiones disponibles
         const outerPad = 24;
@@ -542,12 +780,14 @@ export const DisplayPreview: React.FC<{
         const sH = Math.max(0.1, targetH / baseH);
         const sW = Math.max(0.1, availableW / baseW);
         const raw = fit === 'height' ? sH : fit === 'width' ? sW : Math.min(sH, sW);
-        const scale = snapScale(raw);
+        const previewScale = snapScale(raw);
 
-        const w = Math.round(baseW * scale);
-        const h = Math.round(baseH * scale);
-        const scalePct = Math.round(scale * 100);
+        const w = Math.round(baseW * previewScale);
+        const h = Math.round(baseH * previewScale);
+        const previewScalePct = Math.round(previewScale * 100);
         const { state, color, remainingFmt, phase } = stateInfo(t);
+        const overlayHudActive = hudMenuFor === t.id && expandedId === t.id;
+        const fitLabel = fit === 'contain' ? 'Contener' : fit === 'width' ? 'Ancho' : 'Alto';
 
         return (
           <div
@@ -600,46 +840,136 @@ export const DisplayPreview: React.FC<{
                 </span>
 
                 <div className="d-flex align-items-center flex-wrap gap-2">
-                  <span className="small text-secondary me-1">{scalePct}%</span>
+                <span className="small text-secondary me-1">Vista {previewScalePct}% · Zoom {hudScale}% · {densityName}</span>
 
-                  {/* Grupo 1 */}
-                  <div className="btn-group btn-group-sm" role="group" aria-label="Ajuste">
+                <div className="position-relative">
+                  <div className="d-flex align-items-center gap-2">
+                    <span className="badge text-bg-dark d-none d-md-inline">{fitLabel}</span>
+                    <div className="btn-group btn-group-sm" role="group" aria-label="HUD">
+                      <button
+                        className={overlayHudActive ? 'btn btn-light' : 'btn btn-outline-light'}
+                        onClick={() => toggleHudMenu(t.id)}
+                        ref={el => { hudButtonRefs.current[t.id] = el; }}
+                        title={`Zoom HUD: ${hudScale}% · ${densityName}`}
+                        aria-expanded={overlayHudActive}
+                        aria-controls={`hud-menu-${t.id}`}
+                      >
+                        {density === 'compact' ? '▣' : density === 'expanded' ? '▢' : '▤'}
+                        <span className="d-none d-md-inline ms-1">HUD</span>
+                      </button>
+                    </div>
+                  </div>
+                  <div className="btn-group btn-group-sm ms-2" role="group" aria-label="Zoom del HUD">
                     <button
+                      type="button"
                       className="btn btn-outline-light"
-                      onClick={() => cycleFit(t.id)}
-                      title={`Ajuste: ${fit === 'contain' ? 'Contener' : fit === 'width' ? 'Ajustar al ancho' : 'Ajustar al alto'}`}
+                      onClick={() => nudgeScale(t.id, -5)}
+                      title="Reducir zoom del HUD"
+                      aria-label="Reducir zoom del HUD"
                     >
-                      {fit === 'contain' ? '⤧' : fit === 'width' ? '⇔' : '⇕'}
-                      <span className="d-none d-md-inline ms-1">{fit === 'contain' ? 'Contain' : fit === 'width' ? 'Ancho' : 'Alto'}</span>
+                      −
+                    </button>
+                    <button
+                      type="button"
+                      className="btn btn-outline-light"
+                      onClick={() => nudgeScale(t.id, 5)}
+                      title="Ampliar zoom del HUD"
+                      aria-label="Ampliar zoom del HUD"
+                    >
+                      +
                     </button>
                   </div>
+                  {overlayHudActive && (
+                    <div
+                      id={`hud-menu-${t.id}`}
+                      ref={el => { if (expandedId === t.id) hudMenuRef.current = el; }}
+                      className="hud-config-menu shadow"
+                      role="dialog"
+                      aria-label="Opciones de HUD"
+                    >
+                      <div className="hud-config-menu__section">
+                        <div className="hud-config-menu__label">Ajuste</div>
+                        <div className="btn-group btn-group-sm w-100" role="group" aria-label="Modo de ajuste">
+                          <button type="button" className={`btn ${fit === 'contain' ? 'btn-secondary' : 'btn-outline-secondary'}`} onClick={() => setFitMode(t.id, 'contain')}>
+                            Contener
+                          </button>
+                          <button type="button" className={`btn ${fit === 'width' ? 'btn-secondary' : 'btn-outline-secondary'}`} onClick={() => setFitMode(t.id, 'width')}>
+                            Ancho
+                          </button>
+                          <button type="button" className={`btn ${fit === 'height' ? 'btn-secondary' : 'btn-outline-secondary'}`} onClick={() => setFitMode(t.id, 'height')}>
+                            Alto
+                          </button>
+                        </div>
+                      </div>
+                      <div className="hud-config-menu__section">
+                        <div className="hud-config-menu__label">Tema y efectos</div>
+                        <div className="btn-group btn-group-sm w-100" role="group" aria-label="Tema y efectos">
+                          <button type="button" className={`btn ${(t.displayTheme || 'dark') === 'light' ? 'btn-warning' : 'btn-outline-warning'}`} onClick={() => onToggleTheme(t.id)}>
+                            {(t.displayTheme || 'dark') === 'light' ? '🌞 Claro' : '🌙 Oscuro'}
+                          </button>
+                          <button type="button" className={`btn ${isFxOn(t.id) ? 'btn-outline-warning' : 'btn-warning'}`} onClick={() => toggleFx(t.id)}>
+                            {isFxOn(t.id) ? '✨ FX activos' : '🚫 Sin FX'}
+                          </button>
+                        </div>
+                      </div>
+                      <div className="hud-config-menu__section">
+                        <div className="hud-config-menu__label">Densidad</div>
+                        <div className="btn-group btn-group-sm w-100" role="group" aria-label="Modo de densidad">
+                          <button type="button" className={`btn ${density === 'compact' ? 'btn-secondary' : 'btn-outline-secondary'}`} onClick={() => applyDensity(t.id, 'compact')}>
+                            Compacto
+                          </button>
+                          <button type="button" className={`btn ${density === 'standard' ? 'btn-secondary' : 'btn-outline-secondary'}`} onClick={() => applyDensity(t.id, 'standard')}>
+                            Equilibrado
+                          </button>
+                          <button type="button" className={`btn ${density === 'expanded' ? 'btn-secondary' : 'btn-outline-secondary'}`} onClick={() => applyDensity(t.id, 'expanded')}>
+                            Amplio
+                          </button>
+                        </div>
+                      </div>
+                      <div className="hud-config-menu__section">
+                        <div className="hud-config-menu__label d-flex justify-content-between align-items-center">
+                          <span>Zoom del HUD</span>
+                          <span className="badge text-bg-secondary">{hudScale}%</span>
+                        </div>
+                        <input
+                          type="range"
+                          min={70}
+                          max={140}
+                          step={5}
+                          value={hudScale}
+                          onChange={e => updateScale(t.id, Number(e.target.value))}
+                          className="form-range hud-config-menu__slider"
+                          aria-label="Zoom del HUD"
+                        />
+                        <div className="d-flex justify-content-between text-muted small">
+                          <span>Menos zoom</span>
+                          <span>Más zoom</span>
+                        </div>
+                        <div className="d-flex flex-wrap gap-2 mt-2">
+                          {ZOOM_PRESETS.map(val => (
+                            <button
+                              key={val}
+                              type="button"
+                              className={`btn btn-sm ${hudScale === val ? 'btn-secondary' : 'btn-outline-secondary'}`}
+                              onClick={() => updateScale(t.id, val)}
+                            >
+                              {val}%
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                      <button type="button" className="btn btn-link p-0 small text-decoration-none" onClick={closeHudMenu}>
+                        Cerrar
+                      </button>
+                    </div>
+                  )}
+                </div>
 
                   <div className="toolbar-sep d-none d-sm-block" aria-hidden />
 
-                  {/* Grupo 2 */}
-                  <div className="btn-group btn-group-sm" role="group" aria-label="Tema y efectos">
-                    <button
-                      className={(t.displayTheme || 'dark') === 'light' ? 'btn btn-warning' : 'btn btn-outline-warning'}
-                      onClick={() => onToggleTheme(t.id)}
-                      title="Alternar tema del display"
-                    >
-                      {(t.displayTheme || 'dark') === 'light' ? '🌞' : '🌙'}
-                      <span className="d-none d-md-inline ms-1">Tema</span>
-                    </button>
-                    <button
-                      className={isFxOn(t.id) ? 'btn btn-outline-warning' : 'btn btn-warning'}
-                      onClick={() => toggleFx(t.id)}
-                      title={isFxOn(t.id) ? 'Desactivar efectos' : 'Activar efectos'}
-                    >
-                      {isFxOn(t.id) ? '✨' : '🚫'} <span className="d-none d-md-inline ms-1">FX</span>
-                    </button>
-                  </div>
-
-                  <div className="toolbar-sep d-none d-sm-block" aria-hidden />
-
-                  {/* Grupo 3 */}
+                  {/* Grupo Ventana y salida */}
                   <div className="btn-group btn-group-sm" role="group" aria-label="Ventana y recargar">
-                    <a className="btn btn-outline-light" href={url} target={`SIGAD_DISPLAY_${t.id}`} rel="noreferrer" title="Abrir en ventana">↗<span className="d-none d-md-inline ms-1">Ventana</span></a>
+                    <a className="btn btn-outline-light" href={windowUrl} target={`SIGAD_DISPLAY_${t.id}`} rel="noreferrer" title="Abrir en ventana">↗<span className="d-none d-md-inline ms-1">Ventana</span></a>
                     <button className="btn btn-outline-light" onClick={() => reloadFrame(`prev-exp-${t.id}`)} title="Recargar">↻<span className="d-none d-md-inline ms-1">Recargar</span></button>
                     <button className="btn btn-outline-secondary" onClick={() => setExpandedId(null)} title="Cerrar (Esc)">✕<span className="d-none d-md-inline ms-1">Cerrar</span></button>
                   </div>
@@ -704,10 +1034,10 @@ export const DisplayPreview: React.FC<{
 
                     <iframe
                       id={`prev-exp-${t.id}`}
-                      src={url}
+                      src={baseUrl}
                       title={`preview-expanded-${t.name}`}
                       onLoad={() => markLoaded(t.id)}
-                      style={{ width: baseW, height: baseH, border: 0, transform: `scale(${scale}) translateZ(0)`, transformOrigin: 'top left', willChange: 'transform' }}
+                      style={{ width: baseW, height: baseH, border: 0, transform: `scale(${previewScale}) translateZ(0)`, transformOrigin: 'top left', willChange: 'transform' }}
                     />
 
                     {/* Indicador escala/mode */}
@@ -721,8 +1051,9 @@ export const DisplayPreview: React.FC<{
                         display: 'inline-flex', gap: 8, alignItems: 'center'
                       }}
                     >
-                      <span>{scalePct}%</span>
-                      <span style={{ opacity: .85 }}>{fit}</span>
+                      <span>Vista {previewScalePct}%</span>
+                      <span style={{ opacity: .85 }}>{fitLabel}</span>
+                      <span style={{ opacity: .7 }}>Zoom {hudScale}% · {densityName}</span>
                     </div>
                   </div>
                 </div>

--- a/src/display.tsx
+++ b/src/display.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import "./index.css";
 import ReactDOM from "react-dom/client";
 import dayjs from "dayjs";
+import "dayjs/locale/es";
 import {
   subscribeDisplay,
   subscribeAnnouncements,
@@ -10,74 +11,220 @@ import {
 } from "./displayChannel";
 import { BrandLogo } from "./BrandLogo";
 
+type HudDensity = "compact" | "standard" | "expanded";
+type HudScale = number;
+type ScheduleKind = "round" | "break" | "final";
+
+interface ScheduleItem {
+  label: string;
+  time: string;
+  kind: ScheduleKind;
+}
+
+const HUD_DENSITY_KEY = "sigad-hud-density";
+const HUD_SCALE_KEY = "sigad-hud-scale";
+
+const parseDensity = (value: string | null | undefined): HudDensity | null => {
+  return value === "compact" || value === "standard" || value === "expanded" ? value : null;
+};
+
+const parseScale = (value: string | null | undefined): HudScale | null => {
+  if (!value) return null;
+  const num = Number(value);
+  if (!Number.isFinite(num)) return null;
+  const rounded = Math.round(num);
+  if (rounded < 70 || rounded > 140) return null;
+  return rounded;
+};
+
+const clampScale = (value: HudScale): HudScale => {
+  const rounded = Math.round(value);
+  if (Number.isNaN(rounded)) return 100;
+  return Math.min(140, Math.max(70, rounded));
+};
+
+dayjs.locale("es");
+
 /* ==================== Iconos ==================== */
 const IconClock = (p: React.SVGProps<SVGSVGElement>) => (
   <svg viewBox="0 0 24 24" fill="none" aria-hidden {...p}>
-    <path stroke="currentColor" strokeWidth="1.5" d="M12 8v5l3 2" />
-    <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="1.5" />
-  </svg>
-);
-const IconBolt = (p: React.SVGProps<SVGSVGElement>) => (
-  <svg viewBox="0 0 24 24" fill="none" aria-hidden {...p}>
-    <path
-      d="M13 2 3 14h7l-1 8 10-12h-7l1-8Z"
+    <circle
+      cx="12"
+      cy="12"
+      r="9"
       stroke="currentColor"
       strokeWidth="1.5"
-      fill="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      opacity={0.88}
+    />
+    <path
+      d="M12 6.75v5.3l3.2 1.9"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <circle cx="12" cy="12" r="2.25" fill="currentColor" opacity={0.16} />
+    <path
+      d="M12 3.5v1.4m0 14.2v1.4m8.5-8.5h-1.4m-14.2 0H3.5"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      strokeLinecap="round"
+      opacity={0.45}
     />
   </svg>
 );
 const IconTarget = (p: React.SVGProps<SVGSVGElement>) => (
   <svg viewBox="0 0 24 24" fill="none" aria-hidden {...p}>
-    <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="1.5" />
-    <circle cx="12" cy="12" r="4" stroke="currentColor" strokeWidth="1.5" />
-    <circle cx="12" cy="12" r="1.5" fill="currentColor" />
+    <circle
+      cx="12"
+      cy="12"
+      r="9"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      opacity={0.8}
+    />
+    <circle
+      cx="12"
+      cy="12"
+      r="4.5"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      opacity={0.9}
+    />
+    <path
+      d="M12 7.25v9.5M7.25 12h9.5"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      strokeLinecap="round"
+      opacity={0.55}
+    />
+    <circle cx="12" cy="12" r="1.6" fill="currentColor" />
   </svg>
 );
 const IconCoffee = (p: React.SVGProps<SVGSVGElement>) => (
   <svg viewBox="0 0 24 24" fill="none" aria-hidden {...p}>
     <path
-      d="M3 8h13v5a5 5 0 0 1-5 5H8a5 5 0 0 1-5-5V8Z"
+      d="M4.75 8.5h11.5v4.6A4.9 4.9 0 0 1 11.4 18h-1.3a4.9 4.9 0 0 1-4.9-4.9V8.5Z"
       stroke="currentColor"
       strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
     />
-    <path d="M16 9h2.5a2.5 2.5 0 1 1 0 5H16" stroke="currentColor" strokeWidth="1.5" />
+    <path
+      d="M16.25 9h2.2a2.55 2.55 0 0 1 0 5.1H16"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
     <path
       d="M7 4s1 1 0 2m4-2s1 1 0 2m4-2s1 1 0 2"
       stroke="currentColor"
       strokeWidth="1.5"
       strokeLinecap="round"
     />
+    <path d="M7 19.25h7.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" opacity={0.55} />
   </svg>
 );
 const IconPlay = (p: React.SVGProps<SVGSVGElement>) => (
   <svg viewBox="0 0 24 24" fill="none" aria-hidden {...p}>
-    <path d="m8 5 12 7-12 7V5Z" fill="currentColor" />
+    <path d="m9 6 9 6-9 6V6Z" fill="currentColor" />
+    <path
+      d="M12 3.75c4.55 0 8.25 3.7 8.25 8.25s-3.7 8.25-8.25 8.25S3.75 16.55 3.75 12 7.45 3.75 12 3.75Z"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      opacity={0.55}
+    />
   </svg>
 );
 const IconTrophy = (p: React.SVGProps<SVGSVGElement>) => (
   <svg viewBox="0 0 24 24" fill="none" aria-hidden {...p}>
     <path
-      d="M6 3h12v3a6 6 0 0 1-6 6 6 6 0 0 1-6-6V3Z"
-      stroke="currentColor"
-      strokeWidth="1.5"
-    />
-    <path d="M9 21h6M9 18h6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-    <path
-      d="M18 6h2a2 2 0 0 1-2 2M6 6H4a2 2 0 0 0 2 2"
+      d="M6.5 4h11v2.4a5.5 5.5 0 0 1-5.5 5.5h-0a5.5 5.5 0 0 1-5.5-5.5V4Z"
       stroke="currentColor"
       strokeWidth="1.5"
       strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M9.25 20.25h5.5m-5.5-2.8h5.5"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M17.5 6.4h2.15a2.35 2.35 0 0 1-2.35 2.35M6.5 6.4H4.35A2.35 2.35 0 0 0 6.7 8.75"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
     />
   </svg>
 );
 const IconLayers = (p: React.SVGProps<SVGSVGElement>) => (
   <svg viewBox="0 0 24 24" fill="none" aria-hidden {...p}>
-    <path d="M12 3 3 8l9 5 9-5-9-5Z" stroke="currentColor" strokeWidth="1.5" />
-    <path d="M3 12l9 5 9-5M3 16l9 5 9-5" stroke="currentColor" strokeWidth="1.5" opacity=".6" />
+    <path
+      d="M12 3.6 4.2 8l7.8 4.4L19.8 8 12 3.6Z"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M4.2 12.1 12 16.5l7.8-4.4M4.2 16.2 12 20.6l7.8-4.4"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      opacity={0.65}
+    />
   </svg>
 );
-
+const IconSparkles = (p: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="none" aria-hidden {...p}>
+    <path
+      d="M12 3.5 13.4 7l3.6 1.2L13.4 9.4 12 13l-1.4-3.6L7 8.2 10.6 7 12 3.5Z"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path d="M5.5 4.5 6.2 6.6 8.3 7.3 6.2 8 5.5 10.1 4.8 8 2.7 7.3 4.8 6.6 5.5 4.5Z" fill="currentColor" opacity=".38" />
+    <path d="m18.6 13.2.7 2.1 2.1.7-2.1.7-.7 2.1-.7-2.1-2.1-.7 2.1-.7.7-2.1Z" fill="currentColor" opacity=".38" />
+  </svg>
+);
+const IconBolt = (p: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="none" aria-hidden {...p}>
+    <path
+      d="m12 3-6 10h5v8l7-11h-5l2.6-7H12Z"
+      fill="currentColor"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+const IconFlag = (p: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="none" aria-hidden {...p}>
+    <path d="M5 3.25v17.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    <path
+      d="M5 4.75h10.6l-1.5 3.4 1.5 3.4H5"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
 /* ==================== Helpers ==================== */
 const pad2 = (n: number) => n.toString().padStart(2, "0");
 const fmtClock = (tf: TimeFmt) => (tf === "12" ? "hh:mm A" : "HH:mm");
@@ -96,9 +243,44 @@ function chunk<T>(arr: T[], size: number): T[][] {
   return out;
 }
 
+const timerEquals = (a: DisplayTournament["timer"], b: DisplayTournament["timer"]) =>
+  a.target === b.target &&
+  a.remainingMs === b.remainingMs &&
+  a.running === b.running &&
+  a.label === b.label &&
+  a.mode === b.mode;
+
+function tournamentsEqual(prev: DisplayTournament[], next: DisplayTournament[]) {
+  if (prev === next) return true;
+  if (prev.length !== next.length) return false;
+  for (let i = 0; i < prev.length; i++) {
+    const a = prev[i];
+    const b = next[i];
+    if (!b) return false;
+    if (
+      a.id !== b.id ||
+      a.name !== b.name ||
+      a.game !== b.game ||
+      a.roundsTotal !== b.roundsTotal ||
+      a.roundsCompleted !== b.roundsCompleted ||
+      a.roundMinutes !== b.roundMinutes ||
+      a.breakEnabled !== b.breakEnabled ||
+      a.breakMinutes !== b.breakMinutes ||
+      a.autoStartNext !== b.autoStartNext ||
+      (a.nextRoundMinutes ?? null) !== (b.nextRoundMinutes ?? null) ||
+      a.createdAt !== b.createdAt ||
+      a.theme !== b.theme ||
+      !timerEquals(a.timer, b.timer)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
 /** Itinerario (máx 3) — FIX incluido */
-function computeSchedule(t: DisplayTournament, tf: TimeFmt) {
-  const items: { label: string; time: string }[] = [];
+function computeSchedule(t: DisplayTournament, tf: TimeFmt): ScheduleItem[] {
+  const items: ScheduleItem[] = [];
   let base = Date.now();
 
   const inSomething =
@@ -108,12 +290,20 @@ function computeSchedule(t: DisplayTournament, tf: TimeFmt) {
 
   const remaining = inSomething ? Math.max(0, (t.timer.target ?? 0) - base) : 0;
   if (remaining > 0) {
+    const finishingIndex = inRound ? currentIndex : currentIndex + 1;
+    const finishingKind: ScheduleKind =
+      t.timer.mode === "break"
+        ? "break"
+        : finishingIndex >= t.roundsTotal
+        ? "final"
+        : "round";
     items.push({
       label:
         t.timer.mode === "break"
-          ? "Fin break"
+          ? "Fin del descanso"
           : `Fin ronda ${inRound ? currentIndex : currentIndex + 1}`,
       time: dayjs(base + remaining).format(fmtClock(tf)),
+      kind: finishingKind,
     });
     base += remaining;
   }
@@ -122,12 +312,13 @@ function computeSchedule(t: DisplayTournament, tf: TimeFmt) {
   for (let i = 1; i <= left; i++) {
     if (t.breakEnabled && t.breakMinutes > 0) {
       base += t.breakMinutes * 60_000;
-      items.push({ label: "Break", time: dayjs(base).format(fmtClock(tf)) });
+      items.push({ label: "Descanso", time: dayjs(base).format(fmtClock(tf)), kind: "break" });
     }
     base += t.roundMinutes * 60_000;
     items.push({
       label: `Fin ronda ${currentIndex + i}`,
       time: dayjs(base).format(fmtClock(tf)),
+      kind: currentIndex + i >= t.roundsTotal ? "final" : "round",
     });
   }
   return items.slice(0, 3);
@@ -150,61 +341,103 @@ const Pill = ({ children, isLight }: PillProps) => (
   </span>
 );
 
-interface StatCardProps { label: string; children: React.ReactNode; isLight: boolean }
-const StatCard = ({ label, children, isLight }: StatCardProps) => (
-  <div
-    className={pick(
-      isLight,
-      "rounded-xl border border-zinc-200 bg-white/80 shadow-sm p-4 transition-colors hover:bg-white",
-      "rounded-xl border border-zinc-800 bg-zinc-900/50 p-4 transition-colors hover:bg-zinc-900/70"
-    )}
-  >
-    <div className={pick(isLight, "text-zinc-600 text-[13px]", "text-zinc-400 text-[13px]")}>{label}</div>
-    <div className={pick(isLight, "mt-1.5 font-semibold text-zinc-900", "mt-1.5 font-semibold text-zinc-100")}>{children}</div>
-  </div>
-);
+interface StatCardProps {
+  label: string;
+  children: React.ReactNode;
+  isLight: boolean;
+  density: HudDensity;
+}
+const StatCard = ({ label, children, isLight, density }: StatCardProps) => {
+  const baseClass = pick(
+    isLight,
+    "rounded-xl border border-zinc-200/80 bg-white/80 shadow-[0_12px_28px_rgba(15,23,42,0.12)] backdrop-blur",
+    "rounded-xl border border-white/5 bg-zinc-900/55 shadow-[0_18px_38px_rgba(10,12,26,0.48)] backdrop-blur"
+  );
+  const paddingClass = density === "compact" ? "p-3" : density === "expanded" ? "p-5" : "p-4";
+  const labelClass = pick(
+    isLight,
+    `${density === "compact" ? "text-[12px]" : "text-[13px]"} text-zinc-600`,
+    `${density === "compact" ? "text-[12px]" : "text-[13px]"} text-zinc-400`
+  );
+  const valueMargin = density === "compact" ? "mt-1" : density === "expanded" ? "mt-2" : "mt-1.5";
+  const valueSize = density === "compact" ? "text-[15px]" : density === "expanded" ? "text-lg" : "text-base";
+  const valueClass = pick(
+    isLight,
+    `${valueMargin} font-semibold text-zinc-900 ${valueSize}`,
+    `${valueMargin} font-semibold text-zinc-100 ${valueSize}`
+  );
 
-const TimeBlock = ({
-  value,
-  label,
-  accent,
-  isLight,
-}: {
+  return (
+    <div className={`${baseClass} ${paddingClass}`}>
+      <div className={labelClass}>{label}</div>
+      <div className={valueClass}>{children}</div>
+    </div>
+  );
+};
+
+interface TimeBlockProps {
   value: string;
   label: string;
   accent: "indigo" | "amber";
   isLight: boolean;
-}) => (
-  <div className="group relative overflow-hidden rounded-2xl hud-corners time-ambient">
-    <div className={`neon-border ${accent === "amber" ? "neon-amber" : "neon-indigo"}`} />
-    <div
-      className={pick(
-        isLight,
-        "relative z-10 rounded-2xl bg-zinc-50 px-5 py-4 md:px-6 md:py-5",
-        "relative z-10 rounded-2xl bg-zinc-900/60 px-5 py-4 md:px-6 md:py-5"
-      )}
-    >
+  density: HudDensity;
+}
+
+const TimeBlock = React.memo(
+  ({ value, label, accent, isLight, density }: TimeBlockProps) => {
+    const paddingClass =
+      density === "compact"
+        ? "px-4 py-3 md:px-5 md:py-4"
+        : density === "expanded"
+        ? "px-7 py-6 md:px-8 md:py-7"
+      : "px-5 py-4 md:px-6 md:py-5";
+  const numberClass =
+    density === "compact"
+      ? "text-4xl md:text-5xl"
+      : density === "expanded"
+      ? "text-6xl md:text-8xl"
+      : "text-5xl md:text-7xl";
+  const labelMargin = density === "expanded" ? "mt-1.5" : density === "compact" ? "mt-1" : "mt-1.5";
+  const labelSize = density === "compact" ? "text-[11px]" : "text-xs";
+
+  return (
+    <div className="group relative overflow-hidden rounded-2xl hud-corners time-ambient">
+      <div className={`neon-border ${accent === "amber" ? "neon-amber" : "neon-indigo"}`} />
       <div
         className={pick(
           isLight,
-          "tabular-nums font-black leading-none tracking-tight text-5xl md:text-7xl animate-flipTick will-change-transform digit-glow text-zinc-900",
-          "tabular-nums font-black leading-none tracking-tight text-5xl md:text-7xl animate-flipTick will-change-transform digit-glow text-zinc-100"
-        )}
-        style={{ fontFeatureSettings: "'tnum' on", fontVariantNumeric: "tabular-nums" }}
-      >
-        {value}
-      </div>
-      <div
-        className={pick(
-          isLight,
-          "mt-1 text-xs uppercase tracking-[0.2em] text-zinc-500",
-          "mt-1 text-xs uppercase tracking-[0.2em] text-zinc-400"
+          `relative z-10 rounded-2xl bg-zinc-50 ${paddingClass}`,
+          `relative z-10 rounded-2xl bg-zinc-900/60 ${paddingClass}`
         )}
       >
-        {label}
+        <div
+          className={pick(
+            isLight,
+            `tabular-nums font-black leading-none tracking-tight ${numberClass} animate-flipTick will-change-transform digit-glow text-zinc-900`,
+            `tabular-nums font-black leading-none tracking-tight ${numberClass} animate-flipTick will-change-transform digit-glow text-zinc-100`
+          )}
+          style={{ fontFeatureSettings: "'tnum' on", fontVariantNumeric: "tabular-nums" }}
+        >
+          {value}
+        </div>
+        <div
+          className={pick(
+            isLight,
+            `${labelMargin} ${labelSize} uppercase tracking-[0.24em] text-zinc-500`,
+            `${labelMargin} ${labelSize} uppercase tracking-[0.24em] text-zinc-400`
+          )}
+        >
+          {label}
+        </div>
       </div>
     </div>
-  </div>
+  },
+  (prev, next) =>
+    prev.value === next.value &&
+    prev.label === next.label &&
+    prev.accent === next.accent &&
+    prev.isLight === next.isLight &&
+    prev.density === next.density
 );
 
 const PageDots: React.FC<{ count: number; index: number; isLight: boolean }> = ({
@@ -229,6 +462,521 @@ const PageDots: React.FC<{ count: number; index: number; isLight: boolean }> = (
     </div>
   );
 };
+
+const BokehBackdrop = React.memo(({ isLight, disableFX }: { isLight: boolean; disableFX: boolean }) => {
+  const nodes = useMemo(() => Array.from({ length: 5 }, (_, i) => i + 1), []);
+  if (disableFX) return null;
+  return (
+    <div className={`hud-bokeh ${isLight ? "hud-bokeh--light" : ""}`} aria-hidden>
+      {nodes.map((idx) => (
+        <span key={idx} className={`hud-bokeh__item hud-bokeh__item--${idx}`} />
+      ))}
+    </div>
+  );
+});
+
+interface RoundTrackProps {
+  total: number;
+  current: number;
+  completed: number;
+  isLight: boolean;
+  accent: "round" | "break";
+  stateLabel: string;
+  density: HudDensity;
+  className?: string;
+  hideCaption?: boolean;
+}
+
+const RoundTrack = React.memo(
+  ({
+    total,
+    current,
+    completed,
+    isLight,
+    accent,
+    stateLabel,
+    density,
+    className,
+    hideCaption,
+  }: RoundTrackProps) => {
+    const safeTotal = Math.max(1, total);
+    const safeCurrent = Math.min(safeTotal, Math.max(1, current));
+    const safeCompleted = Math.min(safeTotal, Math.max(0, completed));
+    const maxDots = density === "expanded" ? 14 : density === "compact" ? 8 : 12;
+  let start = Math.max(1, safeCurrent - Math.floor(maxDots / 2));
+  let end = Math.min(safeTotal, start + maxDots - 1);
+  start = Math.max(1, end - maxDots + 1);
+  end = Math.min(safeTotal, start + maxDots - 1);
+  const isCrowdedRange = safeTotal > maxDots;
+  const showLead = !isCrowdedRange && start > 1;
+  const showTail = !isCrowdedRange && end < safeTotal;
+  const nodes = [] as number[];
+  for (let idx = start; idx <= end; idx++) nodes.push(idx);
+
+  const baseProgress = safeTotal > 0 ? Math.max(0, Math.min(100, Math.round((safeCompleted / safeTotal) * 100))) : 0;
+  const barPct = safeTotal > 0
+    ? Math.max(
+        0,
+        Math.min(
+          100,
+          Math.round(((safeCompleted + (accent === "break" ? 0 : 0.35)) / safeTotal) * 100)
+        )
+      )
+    : 0;
+
+  const accentIcon = accent === "break" ? (
+    <IconCoffee className="size-5" />
+  ) : (
+    <IconFlag className="size-5" />
+  );
+  const description = (() => {
+    if (stateLabel === "Terminado") return "El torneo llegó a la meta. Puedes preparar la siguiente fase.";
+    if (stateLabel === "Pausado") return "La ronda está en pausa temporal. Retoma cuando la sala esté lista.";
+    if (accent === "break") return "Momento de descanso antes de retomar las rondas.";
+    return "Mapa visual del avance acumulado de las rondas.";
+  })();
+
+  const subtitleText =
+    density === "compact"
+      ? accent === "break"
+        ? "Descanso"
+        : "Rondas"
+      : accent === "break"
+      ? "Momento de descanso"
+      : "Mapa de rondas";
+  const titleText =
+    density === "compact"
+      ? accent === "break"
+        ? "Descanso en curso"
+        : "Pulso del torneo"
+      : accent === "break"
+      ? "Descanso panorámico"
+      : "Avance general";
+  const metaText =
+    density === "compact" ? `R${safeCurrent}/${safeTotal}` : `Ronda ${safeCurrent} · ${safeCompleted}/${safeTotal}`;
+
+  const classes = [
+    "round-track",
+    "round-track--hud",
+    isLight ? "round-track--light" : "",
+    accent === "break" ? "round-track--break" : "",
+    density === "compact" ? "round-track--density-compact" : "",
+    density === "expanded" ? "round-track--density-expanded" : "",
+    safeTotal <= 8 ? "round-track--mini" : "",
+    isCrowdedRange ? "round-track--crowded" : "",
+    className ?? "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const showCaption = !hideCaption && (density !== "compact" || isCrowdedRange);
+
+  return (
+    <div
+      className={classes}
+    >
+      <div className="round-track__header">
+        <span className="round-track__icon">{accentIcon}</span>
+        <div>
+          <span className="round-track__subtitle">{subtitleText}</span>
+          <div className="round-track__title">{titleText}</div>
+        </div>
+        <span className="round-track__meta">{metaText}</span>
+      </div>
+      <div className="round-track__bar" aria-hidden>
+        <span className="round-track__bar-fill" style={{ width: `${accent === "break" ? baseProgress : Math.max(baseProgress, barPct)}%` }} />
+      </div>
+      <div className="round-track__rail" role="list" aria-label="Avance de rondas">
+        {showLead && (
+          <span className="round-track__ellipsis" aria-hidden>
+            …
+          </span>
+        )}
+        {nodes.map((idx) => {
+          const status = idx <= safeCompleted ? "done" : idx === safeCurrent && safeCompleted !== safeTotal ? "now" : "todo";
+          const label =
+            status === "done" ? "Finalizada" : status === "now" ? "En curso" : accent === "break" ? "Pendiente" : "Pendiente";
+          return (
+            <span
+              key={idx}
+              className={["round-track__node", `round-track__node--${status}`].join(" ")}
+              role="listitem"
+              aria-label={`Ronda ${idx}: ${label}`}
+            >
+              <span className="round-track__label">{idx}</span>
+              <span
+                className={[
+                  "round-track__spark",
+                  status === "now" ? "round-track__spark--active" : "",
+                  status === "done" ? "round-track__spark--trail" : "",
+                ].join(" ")}
+                aria-hidden
+              />
+            </span>
+          );
+        })}
+        {showTail && (
+          <span className="round-track__ellipsis" aria-hidden>
+            …
+          </span>
+        )}
+      </div>
+      {showCaption && <p className="round-track__caption">{description}</p>}
+    </div>
+  );
+  },
+  (prev, next) =>
+    prev.total === next.total &&
+    prev.current === next.current &&
+    prev.completed === next.completed &&
+    prev.isLight === next.isLight &&
+    prev.accent === next.accent &&
+    prev.stateLabel === next.stateLabel &&
+    prev.density === next.density &&
+    prev.className === next.className &&
+    prev.hideCaption === next.hideCaption
+);
+
+interface RoundSummaryPanelProps {
+  track: { total: number; current: number; completed: number } | null;
+  schedule: ScheduleItem[];
+  isLight: boolean;
+  density: HudDensity;
+  accent: "round" | "break";
+  stateLabel: string;
+}
+
+const RoundSummaryPanel = React.memo(
+  ({ track, schedule, isLight, density, accent, stateLabel }: RoundSummaryPanelProps) => {
+    const [primary, ...rest] = schedule;
+
+    const classes = [
+      "round-summary-panel",
+      `round-summary-panel--${density}`,
+      isLight ? "round-summary-panel--light" : "",
+      accent === "break" ? "round-summary-panel--break" : "",
+    ]
+      .filter(Boolean)
+      .join(" ");
+
+    const metaText = (() => {
+      if (!track) return stateLabel === "Sin iniciar" ? "Aún no hay rondas activas" : "Sin rondas activas";
+      return `Ronda ${track.current} · ${track.completed}/${track.total} completadas`;
+    })();
+
+    const kindIcon = (kind: ScheduleKind, size = "size-4") => {
+      if (kind === "break") return <IconCoffee className={size} />;
+      if (kind === "final") return <IconTrophy className={size} />;
+      return <IconFlag className={size} />;
+    };
+
+    return (
+      <section className={classes} aria-label="Resumen de rondas y próximos hitos">
+        <header className="round-summary-panel__header">
+          <div>
+            <span className="round-summary-panel__eyebrow">Rondas y hitos</span>
+            <h3 className="round-summary-panel__title">
+              {accent === "break" ? "Descanso en curso" : "Ruta del torneo"}
+            </h3>
+          </div>
+          <span className="round-summary-panel__meta">{metaText}</span>
+        </header>
+
+        {primary && (
+          <div className="round-summary-panel__highlight">
+            <span
+              className={["round-summary-panel__badge", `round-summary-panel__badge--${primary.kind}`]
+                .filter(Boolean)
+                .join(" ")}
+              aria-hidden
+            >
+              {kindIcon(primary.kind, "size-5")}
+            </span>
+            <div className="round-summary-panel__highlight-body">
+              <span className="round-summary-panel__highlight-label">Próximo hito</span>
+              <span className="round-summary-panel__highlight-title">{primary.label}</span>
+              <time className="round-summary-panel__highlight-time">{primary.time}</time>
+            </div>
+          </div>
+        )}
+
+        <div className="round-summary-panel__content">
+          {track && (
+            <div className="round-summary-panel__track">
+              <RoundTrack
+                total={track.total}
+                completed={track.completed}
+                current={track.current}
+                isLight={isLight}
+                accent={accent}
+                stateLabel={stateLabel}
+                density={density}
+                className="round-track--panel"
+                hideCaption
+              />
+            </div>
+          )}
+          <div className="round-summary-panel__schedule">
+            {rest.length > 0 ? (
+              <>
+                <span className="round-summary-panel__list-label">Después</span>
+                <ul className="round-summary-panel__list">
+                  {rest.map((item, idx) => (
+                    <li
+                      key={`${item.label}-${idx}`}
+                      className={["round-summary-panel__item", `round-summary-panel__item--${item.kind}`]
+                        .filter(Boolean)
+                        .join(" ")}
+                    >
+                      <span className="round-summary-panel__item-icon" aria-hidden>
+                        {kindIcon(item.kind)}
+                      </span>
+                      <div className="round-summary-panel__item-body">
+                        <span className="round-summary-panel__item-label">{item.label}</span>
+                        <time className="round-summary-panel__item-time">{item.time}</time>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </>
+            ) : (
+              <p className="round-summary-panel__empty">
+                {primary
+                  ? "Se mostrará el siguiente bloque cuando concluya este hito."
+                  : "No hay hitos programados para las próximas rondas."}
+              </p>
+            )}
+          </div>
+        </div>
+      </section>
+    );
+  },
+  (prev, next) => {
+    const trackEqual =
+      (prev.track === null && next.track === null) ||
+      (prev.track !== null &&
+        next.track !== null &&
+        prev.track.total === next.track.total &&
+        prev.track.current === next.track.current &&
+        prev.track.completed === next.track.completed);
+
+    const scheduleEqual =
+      prev.schedule.length === next.schedule.length &&
+      prev.schedule.every((item, idx) => {
+        const other = next.schedule[idx];
+        return !!other && item.label === other.label && item.time === other.time && item.kind === other.kind;
+      });
+
+    return (
+      trackEqual &&
+      scheduleEqual &&
+      prev.isLight === next.isLight &&
+      prev.density === next.density &&
+      prev.accent === next.accent &&
+      prev.stateLabel === next.stateLabel
+    );
+  }
+);
+
+interface ProgressPanelProps {
+  isLight: boolean;
+  accent: "indigo" | "amber";
+  displayPct: number;
+  transitionClass: string;
+  stateLabel: string;
+  nextEvent: ScheduleItem | null;
+  remaining: number;
+  mode: DisplayTournament["timer"]["mode"] | null;
+  currentRound: number | null;
+  roundMinutes: number;
+  breakMinutes: number;
+  breakEnabled: boolean;
+  density: HudDensity;
+  fxDisabled: boolean;
+}
+
+const ProgressPanel = React.memo(
+  ({
+    isLight,
+    accent,
+    displayPct,
+    transitionClass,
+    stateLabel,
+    nextEvent,
+    remaining,
+    mode,
+    currentRound,
+    roundMinutes,
+    breakMinutes,
+    breakEnabled,
+    density,
+    fxDisabled,
+  }: ProgressPanelProps) => {
+    const palette = useMemo(() => {
+      if (accent === "amber") {
+        return { start: "#facc15", mid: "#fb923c", end: "#f43f5e" };
+      }
+      if (isLight) {
+      return { start: "#38bdf8", mid: "#6366f1", end: "#a855f7" };
+    }
+    return { start: "#22d3ee", mid: "#6366f1", end: "#c084fc" };
+  }, [accent, isLight]);
+
+  const { h, m, s } = formatSplit(remaining);
+  const pct = Math.round(displayPct);
+  const isBreak = mode === "break";
+  const icon = isBreak ? <IconCoffee className="size-5" /> : <IconPlay className="size-5" />;
+  const subtitle = isBreak ? "Momento de descanso" : "Ritmo del torneo";
+  const title = (() => {
+    if (!mode) return "Temporizador listo";
+    if (isBreak) {
+      if (!breakEnabled) return "Descanso libre";
+      return breakMinutes > 0 ? `Descanso de ${breakMinutes} min` : "Descanso en progreso";
+    }
+    if (mode === "round") {
+      if (stateLabel === "Terminado") return "Ronda finalizada";
+      return currentRound ? `Ronda ${currentRound} en curso` : "Ronda en curso";
+    }
+    return "Temporizador activo";
+  })();
+
+  const pacePrimary = isBreak
+    ? breakEnabled && breakMinutes > 0
+      ? `${breakMinutes} min`
+      : "Flexible"
+    : roundMinutes > 0
+    ? `${roundMinutes} min`
+    : "Flexible";
+  const paceSecondary = isBreak ? "duración del descanso" : "duración de la ronda";
+  const nextPrimary = nextEvent ? nextEvent.label : stateLabel;
+  const nextSecondary = nextEvent ? nextEvent.time : "seguimiento en vivo";
+  const nextIcon = nextEvent
+    ? nextEvent.kind === "break"
+      ? <IconCoffee className="size-4" />
+      : nextEvent.kind === "final"
+      ? <IconTrophy className="size-4" />
+      : <IconFlag className="size-4" />
+    : <IconTarget className="size-4" />;
+
+  const accentStyle = useMemo(
+    () =>
+      ({
+        ["--accent-start" as any]: palette.start,
+        ["--accent-mid" as any]: palette.mid,
+        ["--accent-end" as any]: palette.end,
+        ["--progress" as any]: displayPct,
+        ["--progress-ratio" as any]: Math.max(0, Math.min(1, displayPct / 100)),
+      }) as React.CSSProperties,
+    [palette.end, palette.mid, palette.start, displayPct]
+  );
+
+  const freezeMotion = transitionClass === "no-transition" || fxDisabled;
+  const fillMotionClass = freezeMotion ? "no-transition" : "";
+  const showBeamFX = !fxDisabled;
+
+  const densityClass =
+    density === "compact"
+      ? "progress-panel--compact"
+      : density === "expanded"
+      ? "progress-panel--expanded"
+      : "";
+
+  return (
+    <div
+      className={["progress-panel", isLight ? "progress-panel--light" : "", densityClass].filter(Boolean).join(" ")}
+      style={accentStyle}
+    >
+      <span className="progress-panel__halo" aria-hidden />
+      <div className="progress-panel__header">
+        <span className="progress-panel__icon">{icon}</span>
+        <div>
+          <span className="progress-panel__subtitle">{subtitle}</span>
+          <div className="progress-panel__title">{title}</div>
+        </div>
+        <span className="progress-panel__chip">
+          <span className="progress-panel__chipIcon" aria-hidden>
+            <IconSparkles className="size-4" />
+          </span>
+          <span className="progress-panel__chipMeta">
+            <span className="progress-panel__chipValue">
+              {pct}
+              <sup>%</sup>
+            </span>
+            <span className="progress-panel__chipLabel">{stateLabel}</span>
+          </span>
+        </span>
+      </div>
+
+      <div className="progress-panel__meter">
+        <div className={["progress-beam", freezeMotion ? "progress-beam--static" : ""].join(" ")}>
+          <div className={["progress-beam__fill", fillMotionClass].join(" ")} />
+          {showBeamFX && (
+            <>
+              <span className={["progress-beam__glow", freezeMotion ? "no-transition" : ""].join(" ")} aria-hidden />
+              <span className={["progress-beam__spark", freezeMotion ? "no-transition" : ""].join(" ")} aria-hidden />
+              <span className={["progress-beam__shine", freezeMotion ? "no-transition" : ""].join(" ")} aria-hidden />
+            </>
+          )}
+        </div>
+        <div className="progress-panel__scale" aria-hidden>
+          {Array.from({ length: 5 }).map((_, idx) => (
+            <span key={idx} className="progress-panel__tick" style={{ left: `${idx * 25}%` }} />
+          ))}
+        </div>
+      </div>
+
+      <div className="progress-panel__legend">
+        <div className="progress-panel__fact">
+          <span className="progress-panel__factIcon" aria-hidden>
+            <IconClock className="size-4" />
+          </span>
+          <span>
+            <strong>
+              {h}:{m}:{s}
+            </strong>
+            <small>tiempo restante</small>
+          </span>
+        </div>
+        <div className="progress-panel__fact">
+          <span className="progress-panel__factIcon" aria-hidden>
+            <IconBolt className="size-4" />
+          </span>
+          <span>
+            <strong>{pacePrimary}</strong>
+            <small>{paceSecondary}</small>
+          </span>
+        </div>
+        <div className="progress-panel__fact progress-panel__fact--wide">
+          <span className="progress-panel__factIcon" aria-hidden>
+            {nextIcon}
+          </span>
+          <span>
+            <strong>{nextPrimary}</strong>
+            <small>{nextSecondary}</small>
+          </span>
+        </div>
+      </div>
+    </div>
+  },
+  (prev, next) =>
+    prev.isLight === next.isLight &&
+    prev.accent === next.accent &&
+    prev.displayPct === next.displayPct &&
+    prev.transitionClass === next.transitionClass &&
+    prev.stateLabel === next.stateLabel &&
+    prev.remaining === next.remaining &&
+    prev.mode === next.mode &&
+    prev.currentRound === next.currentRound &&
+    prev.roundMinutes === next.roundMinutes &&
+    prev.breakMinutes === next.breakMinutes &&
+    prev.breakEnabled === next.breakEnabled &&
+    prev.density === next.density &&
+    prev.fxDisabled === next.fxDisabled &&
+    ((prev.nextEvent === next.nextEvent && prev.nextEvent !== null) ||
+      (prev.nextEvent?.label === next.nextEvent?.label &&
+        prev.nextEvent?.time === next.nextEvent?.time &&
+        prev.nextEvent?.kind === next.nextEvent?.kind))
+);
 
 /* ==================== Super Header (solo visual) ==================== */
 const SuperHeader: React.FC<{
@@ -377,8 +1125,60 @@ const Display: React.FC = () => {
   const [connected, setConnected] = useState(false); // reservado por si muestras estado de conexión
   const [page, setPage] = useState(0);
 
+  const [density, setDensity] = useState<HudDensity>(() => {
+    const param = parseDensity(getParam("hud"));
+    if (param) return param;
+    if (typeof window !== "undefined") {
+      try {
+        const stored = parseDensity(window.localStorage.getItem(HUD_DENSITY_KEY));
+        if (stored) return stored;
+      } catch {}
+    }
+    return "standard";
+  });
+
+  const [hudScale, setHudScale] = useState<HudScale>(() => {
+    const param = parseScale(getParam("scale"));
+    if (param) return param;
+    if (typeof window !== "undefined") {
+      try {
+        const stored = parseScale(window.localStorage.getItem(HUD_SCALE_KEY));
+        if (stored) return stored;
+      } catch {}
+    }
+    return 100;
+  });
+
   const fixedId = useRef<string | null>(getParam("id"));
-  const disableFX = getParam("nofx") === "1";
+  const disableFxParam = getParam("nofx") === "1";
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    try {
+      return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    } catch {
+      return false;
+    }
+  });
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+      const listener = (ev: MediaQueryListEvent) => setPrefersReducedMotion(ev.matches);
+      setPrefersReducedMotion(mq.matches);
+      if (typeof mq.addEventListener === "function") {
+        mq.addEventListener("change", listener);
+        return () => mq.removeEventListener("change", listener);
+      }
+      const legacy = mq as MediaQueryList & { addListener?: (cb: (ev: MediaQueryListEvent) => void) => void; removeListener?: (cb: (ev: MediaQueryListEvent) => void) => void };
+      if (typeof legacy.addListener === "function") {
+        legacy.addListener(listener);
+        return () => legacy.removeListener?.(listener);
+      }
+    } catch {
+      return;
+    }
+  }, []);
+  const disableFX = disableFxParam || prefersReducedMotion;
 
   const [now, setNow] = useState<number>(Date.now());
   useEffect(() => {
@@ -387,10 +1187,57 @@ const Display: React.FC = () => {
   }, []);
 
   useEffect(() => {
+    try {
+      window.localStorage.setItem(HUD_DENSITY_KEY, density);
+    } catch {}
+  }, [density]);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(HUD_SCALE_KEY, String(hudScale));
+    } catch {}
+  }, [hudScale]);
+
+  useEffect(() => {
+    const onMessage = (ev: MessageEvent) => {
+      if (ev.origin && ev.origin !== window.location.origin) return;
+      const data = ev.data as { type?: string; value?: unknown } | null;
+      if (data?.type === "HUD_DENSITY") {
+        const raw = typeof data.value === "string" ? data.value : null;
+        const next = parseDensity(raw);
+        if (next) setDensity(next);
+      } else if (data?.type === "HUD_SCALE") {
+        const raw = typeof data.value === "number" ? data.value : Number(data.value);
+        const next = parseScale(Number.isFinite(raw) ? String(raw) : null);
+        if (next) setHudScale(clampScale(next));
+      }
+    };
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, []);
+
+  useEffect(() => {
+    const onStorage = (ev: StorageEvent) => {
+      if (!ev.key) return;
+      if (ev.storageArea !== window.localStorage) return;
+      if (ev.key === HUD_DENSITY_KEY) {
+        const next = parseDensity(ev.newValue);
+        if (next) setDensity(next);
+      } else if (ev.key === HUD_SCALE_KEY) {
+        const next = parseScale(ev.newValue);
+        if (next) setHudScale(clampScale(next));
+      }
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  useEffect(() => {
     const unsub = subscribeDisplay((s) => {
-      setConnected(true);
-      setTimeFmt(s.timeFmt);
-      setTournaments(s.tournaments || []);
+      setConnected((prev) => (prev ? prev : true));
+      setTimeFmt((prev) => (prev === s.timeFmt ? prev : s.timeFmt));
+      const incoming = s.tournaments || [];
+      setTournaments((prev) => (tournamentsEqual(prev, incoming) ? prev : incoming));
     });
     return unsub;
   }, []);
@@ -408,8 +1255,8 @@ const Display: React.FC = () => {
     return Math.max(0, remainingMs || 0);
   }, [active, now]);
   const { h, m, s } = formatSplit(remaining);
-  const schedule = active ? computeSchedule(active, timeFmt) : [];
-
+  const schedule: ScheduleItem[] = active ? computeSchedule(active, timeFmt) : [];
+  const nextEvent = schedule[0] ?? null;
   const progressPct = useMemo(() => {
     if (!active) return 0;
     const total =
@@ -427,19 +1274,24 @@ const Display: React.FC = () => {
   useEffect(() => {
     if (cycleKey !== lastKeyRef.current) {
       lastKeyRef.current = cycleKey;
-      setDisplayPct(0);
-      requestAnimationFrame(() => setDisplayPct(progressPct));
+      if (disableFX) {
+        setDisplayPct(progressPct);
+      } else {
+        setDisplayPct(0);
+        requestAnimationFrame(() => setDisplayPct(progressPct));
+      }
     } else {
-      setDisplayPct((prev) => Math.max(prev, progressPct));
+      setDisplayPct((prev) => (disableFX ? progressPct : Math.max(prev, progressPct)));
     }
-  }, [cycleKey, progressPct]);
+  }, [cycleKey, progressPct, disableFX]);
 
   const prevShownRef = useRef(0);
   const transitionClass = useMemo(() => {
+    if (disableFX) return "no-transition";
     const prev = prevShownRef.current;
     const increasing = displayPct >= prev;
     return increasing || displayPct === 0 ? "transition-width" : "no-transition";
-  }, [displayPct]);
+  }, [displayPct, disableFX]);
   useEffect(() => {
     prevShownRef.current = displayPct;
   }, [displayPct]);
@@ -450,7 +1302,23 @@ const Display: React.FC = () => {
     return expired ? "Terminado" : active.timer.running ? "En curso" : active.timer.target ? "Pausado" : "Sin iniciar";
   }, [active, remaining]);
 
+  const trackData = useMemo(() => {
+    if (!active) return null;
+    const total = Math.max(1, active.roundsTotal || 1);
+    const completed = Math.min(active.roundsCompleted, total);
+    const running = active.timer.target !== null && (active.timer.running || active.timer.remainingMs > 0);
+    const inRound = running && active.timer.mode === "round";
+    const current =
+      stateLabel === "Terminado"
+        ? total
+        : inRound
+        ? Math.min(total, active.roundsCompleted + 1)
+        : Math.min(total, Math.max(1, completed || 1));
+    return { total, completed, current };
+  }, [active, stateLabel]);
+
   const accent: "indigo" | "amber" = active?.timer.mode === "break" ? "amber" : "indigo";
+  const trackAccent: "break" | "round" = active?.timer.mode === "break" ? "break" : "round";
   const isLight = active?.theme === "light";
 
   const pages = useMemo(() => chunk(tournaments, 3), [tournaments]);
@@ -464,14 +1332,92 @@ const Display: React.FC = () => {
     return () => clearInterval(id);
   }, [pages.length]);
 
+  const shellClass = [
+    pick(
+      isLight ?? false,
+      "min-h-screen w-full relative overflow-hidden light text-zinc-900 bg-gradient-to-b from-white via-zinc-50 to-zinc-100",
+      "min-h-screen w-full relative overflow-hidden text-zinc-100 bg-gradient-to-b from-slate-950 via-neutral-950 to-black"
+    ),
+    `hud-density-${density}`,
+    "display-shell",
+  ].join(" ");
+
+  const frameDensityClass =
+    density === "compact"
+      ? "hud-frame--compact"
+      : density === "expanded"
+      ? "hud-frame--expanded"
+      : "";
+
+  const frameScaleStyle = useMemo(() => {
+    const zoom = clampScale(hudScale) / 100;
+    const zoomExtra = Math.max(0, zoom - 1);
+    return {
+      ["--hud-zoom" as any]: zoom.toString(),
+      ["--hud-zoom-extra" as any]: zoomExtra.toString(),
+      transform: `scale(${zoom})`,
+      transformOrigin: "top center",
+    } as React.CSSProperties;
+  }, [hudScale]);
+
+  const headingClass = pick(
+    !!isLight,
+    `${
+      density === "compact"
+        ? "mb-4 text-[1.7rem] md:text-[2.45rem]"
+        : density === "expanded"
+        ? "mb-6 text-[2.5rem] md:text-[3.35rem]"
+        : "mb-5 text-2xl md:text-4xl"
+    } font-extrabold tracking-tight text-balance text-zinc-900`,
+    `${
+      density === "compact"
+        ? "mb-4 text-[1.7rem] md:text-[2.45rem]"
+        : density === "expanded"
+        ? "mb-6 text-[2.5rem] md:text-[3.35rem]"
+        : "mb-5 text-2xl md:text-4xl"
+    } font-extrabold tracking-tight text-balance`
+  );
+
+  const timeGridClass = `grid grid-cols-3 ${
+    density === "compact"
+      ? "gap-[0.55rem]"
+      : density === "expanded"
+      ? "gap-[1.1rem]"
+      : "gap-[0.85rem]"
+  }`;
+  const statsGridClass = [
+    "grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3",
+    density === "compact"
+      ? "gap-[0.55rem] text-[13px]"
+      : density === "expanded"
+      ? "gap-[1.1rem] text-[15px]"
+      : "gap-[0.85rem] text-[14px]",
+  ].join(" ");
+  const columnsClass = [
+    "hud-columns",
+    density === "compact" ? "hud-columns--compact" : "",
+    density === "expanded" ? "hud-columns--expanded" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+  const stackGapClass =
+    density === "compact"
+      ? "flex flex-col gap-[0.58rem]"
+      : density === "expanded"
+      ? "flex flex-col gap-[1.15rem]"
+      : "flex flex-col gap-[0.82rem]";
+  const hasTrack = !!trackData;
+  const hasSchedule = schedule.length > 0;
+  const sideStackClass = [
+    "hud-side-stack",
+    density === "compact" ? "hud-side-stack--compact" : "",
+    density === "expanded" ? "hud-side-stack--expanded" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   return (
-    <div
-      className={pick(
-        isLight ?? false,
-        "min-h-screen w-full relative overflow-hidden light text-zinc-900 bg-gradient-to-b from-white via-zinc-50 to-zinc-100",
-        "min-h-screen w-full relative overflow-hidden text-zinc-100 bg-gradient-to-b from-slate-950 via-neutral-950 to-black"
-      )}
-    >
+    <div className={shellClass} data-density={density}>
       {/* Fondo */}
       <div className="pointer-events-none absolute inset-0">
         <div
@@ -483,6 +1429,7 @@ const Display: React.FC = () => {
         />
         {!disableFX && <div className={pick(isLight ?? false, "noise-layer opacity-[.04]", "noise-layer opacity-10")} />}
         <div className={pick(isLight ?? false, "bg-logo bg-logo--light", "bg-logo")} />
+        <BokehBackdrop isLight={!!isLight} disableFX={disableFX} />
         {!disableFX && <div className={pick(isLight ?? false, "scanlines opacity-[.03]", "scanlines opacity-[.06]")} />}
         {!disableFX && (
           <>
@@ -529,11 +1476,18 @@ const Display: React.FC = () => {
         {/* HUD principal */}
         {active && (
           <section
-            className={pick(
-              isLight ?? false,
-              "relative overflow-hidden rounded-3xl border border-zinc-200 bg-white/70 shadow-sm backdrop-blur p-6 md:p-8 hud-frame sweep",
-              "relative overflow-hidden rounded-3xl border border-zinc-800 bg-zinc-900/60 p-6 md:p-8 hud-frame sweep"
-            )}
+            className={[
+              pick(
+                isLight ?? false,
+                "relative overflow-hidden rounded-3xl border border-zinc-200 bg-white/70 shadow-sm backdrop-blur p-6 md:p-8 hud-frame sweep",
+                "relative overflow-hidden rounded-3xl border border-zinc-800 bg-zinc-900/60 p-6 md:p-8 hud-frame sweep"
+              ),
+              frameDensityClass,
+            ]
+              .filter(Boolean)
+              .join(" ")}
+            style={frameScaleStyle}
+            data-scale={clampScale(hudScale)}
           >
             {/* Encabezado */}
             <div className="flex flex-wrap items-center gap-3 mb-6">
@@ -543,7 +1497,9 @@ const Display: React.FC = () => {
 
               <span className={pick(!!isLight, "text-zinc-600 text-sm inline-flex items-center gap-2", "text-zinc-300 text-sm inline-flex items-center gap-2")}>
                 <IconLayers className={pick(!!isLight, "size-4 text-zinc-500", "size-4 text-zinc-400")} />
-                {active.timer.mode === "break" ? <>Break</> : <>Ronda • {active.timer.mode === "round" ? active.roundsCompleted + 1 : active.roundsCompleted} / {active.roundsTotal}</>}
+                {active.timer.mode === "break"
+                  ? <>Descanso</>
+                  : <>Ronda • {active.timer.mode === "round" ? active.roundsCompleted + 1 : active.roundsCompleted} / {active.roundsTotal}</>}
               </span>
 
               <span className={pick(!!isLight, "ml-auto text-zinc-600 text-sm inline-flex items-center gap-2", "ml-auto text-zinc-300 text-sm inline-flex items-center gap-2")}>
@@ -553,13 +1509,7 @@ const Display: React.FC = () => {
             </div>
 
             {/* Título */}
-            <h1
-              className={pick(
-                !!isLight,
-                "mb-5 text-2xl md:text-4xl font-extrabold tracking-tight text-balance text-zinc-900",
-                "mb-5 text-2xl md:text-4xl font-extrabold tracking-tight text-balance"
-              )}
-            >
+            <h1 className={headingClass}>
               <span
                 className={pick(
                   !!isLight,
@@ -572,126 +1522,125 @@ const Display: React.FC = () => {
             </h1>
 
             {/* HH : MM : SS */}
-            <div className="grid grid-cols-3 gap-4 mb-7" aria-live="polite">
-              <TimeBlock value={h} label="HORAS" accent={active?.timer.mode === "break" ? "amber" : "indigo"} isLight={!!isLight} />
-              <TimeBlock value={m} label="MINUTOS" accent={active?.timer.mode === "break" ? "amber" : "indigo"} isLight={!!isLight} />
-              <TimeBlock value={s} label="SEGUNDOS" accent={active?.timer.mode === "break" ? "amber" : "indigo"} isLight={!!isLight} />
-            </div>
+            <div className={columnsClass}>
+              <div className={stackGapClass} aria-live="polite">
+                <div className={timeGridClass}>
+                  <TimeBlock
+                    value={h}
+                    label="HORAS"
+                    accent={active?.timer.mode === "break" ? "amber" : "indigo"}
+                    isLight={!!isLight}
+                    density={density}
+                  />
+                  <TimeBlock
+                    value={m}
+                    label="MINUTOS"
+                    accent={active?.timer.mode === "break" ? "amber" : "indigo"}
+                    isLight={!!isLight}
+                    density={density}
+                  />
+                  <TimeBlock
+                    value={s}
+                    label="SEGUNDOS"
+                    accent={active?.timer.mode === "break" ? "amber" : "indigo"}
+                    isLight={!!isLight}
+                    density={density}
+                  />
+                </div>
 
-            {/* Stats */}
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6 text-sm">
-              <StatCard label="Estado" isLight={!!isLight}>
-                <span
-                  className={(() => {
-                    const base = "inline-flex items-center gap-2";
-                    if (stateLabel === "En curso") return pick(!!isLight, `${base} text-emerald-600`, `${base} text-emerald-400`);
-                    if (stateLabel === "Pausado") return pick(!!isLight, `${base} text-amber-600`, `${base} text-amber-400`);
-                    if (stateLabel === "Terminado") return pick(!!isLight, `${base} text-rose-600`, `${base} text-rose-400`);
-                    return pick(!!isLight, `${base} text-zinc-800`, `${base} text-zinc-100`);
-                  })()}
-                >
-                  <span className="relative inline-flex">
+                <div className={statsGridClass}>
+                  <StatCard label="Estado" isLight={!!isLight} density={density}>
                     <span
                       className={(() => {
-                        if (stateLabel === "En curso") return "status-dot bg-emerald-500";
-                        if (stateLabel === "Pausado") return "status-dot bg-amber-500";
-                        if (stateLabel === "Terminado") return "status-dot bg-rose-500";
-                        return "status-dot bg-zinc-400";
+                        const base = "inline-flex items-center gap-2";
+                        if (stateLabel === "En curso")
+                          return pick(!!isLight, `${base} text-emerald-600`, `${base} text-emerald-400`);
+                        if (stateLabel === "Pausado")
+                          return pick(!!isLight, `${base} text-amber-600`, `${base} text-amber-400`);
+                        if (stateLabel === "Terminado")
+                          return pick(!!isLight, `${base} text-rose-600`, `${base} text-rose-400`);
+                        return pick(!!isLight, `${base} text-zinc-800`, `${base} text-zinc-100`);
                       })()}
-                    />
-                    {(stateLabel === "En curso" || stateLabel === "Pausado") && (
-                      <span className={stateLabel === "En curso" ? "status-ping bg-emerald-500" : "status-ping bg-amber-500"} />
-                    )}
-                  </span>
-                  {stateLabel}
-                </span>
-              </StatCard>
+                    >
+                      <span className="relative inline-flex">
+                        <span
+                          className={(() => {
+                            if (stateLabel === "En curso") return "status-dot bg-emerald-500";
+                            if (stateLabel === "Pausado") return "status-dot bg-amber-500";
+                            if (stateLabel === "Terminado") return "status-dot bg-rose-500";
+                            return "status-dot bg-zinc-400";
+                          })()}
+                        />
+                        {(stateLabel === "En curso" || stateLabel === "Pausado") && (
+                          <span className={stateLabel === "En curso" ? "status-ping bg-emerald-500" : "status-ping bg-amber-500"} />
+                        )}
+                      </span>
+                      {stateLabel}
+                    </span>
+                  </StatCard>
 
-              <StatCard label="ETA fin torneo" isLight={!!isLight}>
-                {(() => {
-                  const perRound = active.roundMinutes * 60_000;
-                  const perBreak = (active.breakEnabled ? active.breakMinutes : 0) * 60_000;
-                  const inRound =
-                    active.timer.target !== null &&
-                    (active.timer.running || active.timer.remainingMs > 0) &&
-                    active.timer.mode === "round";
-                  const left =
-                    active.roundsTotal - (inRound ? active.roundsCompleted + 1 : active.roundsCompleted);
-                  const eta =
-                    remaining +
-                    Math.max(0, left) * (perRound + (active.breakEnabled && active.breakMinutes > 0 ? perBreak : 0));
-                  return eta > 0 ? dayjs(Date.now() + eta).format(fmtClock(timeFmt)) : "-";
-                })()}
-              </StatCard>
+                  <StatCard label="ETA fin torneo" isLight={!!isLight} density={density}>
+                    {(() => {
+                      const perRound = active.roundMinutes * 60_000;
+                      const perBreak = (active.breakEnabled ? active.breakMinutes : 0) * 60_000;
+                      const inRound =
+                        active.timer.target !== null &&
+                        (active.timer.running || active.timer.remainingMs > 0) &&
+                        active.timer.mode === "round";
+                      const left =
+                        active.roundsTotal - (inRound ? active.roundsCompleted + 1 : active.roundsCompleted);
+                      const eta =
+                        remaining +
+                        Math.max(0, left) * (perRound + (active.breakEnabled && active.breakMinutes > 0 ? perBreak : 0));
+                      return eta > 0 ? dayjs(Date.now() + eta).format(fmtClock(timeFmt)) : "-";
+                    })()}
+                  </StatCard>
 
-              <StatCard label="Break" isLight={!!isLight}>
-                <span className={pick(!!isLight, "inline-flex items-center gap-2 text-zinc-700", "inline-flex items-center gap-2 text-zinc-200")}>
-                  <IconCoffee className={pick(!!isLight, "size-4 text-zinc-500", "size-4 text-zinc-400")} />
-                  {active.breakEnabled ? `${active.breakMinutes} min` : "No habilitado"}
-                </span>
-              </StatCard>
-            </div>
-
-            {/* Progreso */}
-            <div className="mb-2">
-              <div
-                className={pick(
-                  !!isLight,
-                  "neon-progress h-2 w-full overflow-hidden rounded-full bg-zinc-200/70 relative",
-                  "neon-progress h-2 w-full overflow-hidden rounded-full bg-zinc-800/80 relative"
-                )}
-                style={
-                  {
-                    ["--p" as any]: displayPct,
-                    ["--c1" as any]: accent === "amber" ? "#FFB457" : isLight ? "#0ea5e9" : "#00eaff",
-                    ["--c2" as any]: accent === "amber" ? "#FF3D81" : isLight ? "#6366f1" : "#8b5cf6",
-                    color: "var(--c2)",
-                  } as React.CSSProperties
-                }
-              >
-                <div className={`h-full progress-stripes progress-fill ${transitionClass}`} style={{ width: `${displayPct}%` }} />
-                <span className="progress-comet" aria-hidden />
-                <span className="progress-tip" aria-hidden />
-                <span className="progress-edge" aria-hidden />
-              </div>
-              <div className={pick(!!isLight, "mt-2 text-[12px] text-zinc-600 flex items-center gap-2", "mt-2 text-[12px] text-zinc-400 flex items-center gap-2")}>
-                <IconPlay className={pick(!!isLight, "size-3.5 text-zinc-500", "size-3.5 text-zinc-400")} />
-                {active.timer.mode === "break" ? "Progreso del break" : "Progreso de la ronda"}
-              </div>
-            </div>
-
-            {/* Hitos */}
-            {schedule.length > 0 && (
-              <div
-                className={pick(
-                  !!isLight,
-                  "mt-5 rounded-2xl border border-zinc-200 bg-white/75 p-4 shadow-sm",
-                  "mt-5 rounded-2xl border border-zinc-800 bg-zinc-900/60 p-4"
-                )}
-              >
-                <div className={pick(!!isLight, "text-zinc-600 text-sm mb-2", "text-zinc-400 text-sm mb-2")}>
-                  Próximos hitos
-                </div>
-                <div className="flex flex-wrap gap-2">
-                  {schedule.map((it, i) => (
+                  <StatCard label="Descanso" isLight={!!isLight} density={density}>
                     <span
-                      key={i}
                       className={pick(
                         !!isLight,
-                        "inline-flex items-center gap-2 rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-sm chip-glow",
-                        "inline-flex items-center gap-2 rounded-lg border border-zinc-700 bg-zinc-800/60 px-3 py-1.5 text-sm chip-glow"
+                        "inline-flex items-center gap-2 text-zinc-700",
+                        "inline-flex items-center gap-2 text-zinc-200"
                       )}
                     >
-                      <IconClock className={pick(!!isLight, "size-4 text-zinc-500", "size-4 text-zinc-400")} />
-                      <span className={pick(!!isLight, "text-zinc-600", "text-zinc-300")}>{it.label}:</span>
-                      <strong className={pick(!!isLight, "tracking-tight text-zinc-900", "tracking-tight text-zinc-100")}>
-                        {it.time}
-                      </strong>
+                      <IconCoffee className={pick(!!isLight, "size-4 text-zinc-500", "size-4 text-zinc-400")} />
+                      {active.breakEnabled ? `${active.breakMinutes} min` : "No habilitado"}
                     </span>
-                  ))}
+                  </StatCard>
                 </div>
               </div>
-            )}
+
+              <div className={sideStackClass}>
+                <ProgressPanel
+                  isLight={!!isLight}
+                  accent={accent}
+                  displayPct={displayPct}
+                  transitionClass={transitionClass}
+                  stateLabel={stateLabel}
+                  nextEvent={nextEvent}
+                  remaining={remaining}
+                  mode={active.timer.mode ?? null}
+                  currentRound={trackData?.current ?? null}
+                  roundMinutes={active.roundMinutes}
+                  breakMinutes={active.breakMinutes}
+                  breakEnabled={active.breakEnabled}
+                  density={density}
+                  fxDisabled={disableFX}
+                />
+
+                {(hasTrack || hasSchedule) && (
+                  <RoundSummaryPanel
+                    track={trackData}
+                    schedule={schedule}
+                    isLight={!!isLight}
+                    density={density}
+                    accent={trackAccent}
+                    stateLabel={stateLabel}
+                  />
+                )}
+              </div>
+            </div>
           </section>
         )}
 
@@ -721,7 +1670,7 @@ const Display: React.FC = () => {
                       <span className={pick(!!lightCard, "text-zinc-600", "text-zinc-300")}>
                         {t.timer.mode === "break" ? (
                           <span className="inline-flex items-center gap-1.5">
-                            <IconCoffee className={pick(!!lightCard, "size-3.5 text-zinc-500", "size-3.5 text-zinc-400")} /> Break
+                            <IconCoffee className={pick(!!lightCard, "size-3.5 text-zinc-500", "size-3.5 text-zinc-400")} /> Descanso
                           </span>
                         ) : (
                           <>Ronda • {roundIdx} / {t.roundsTotal}</>

--- a/src/index.css
+++ b/src/index.css
@@ -20,6 +20,7 @@ body { overscroll-behavior: none; background: #000; -webkit-font-smoothing: anti
 :root{
   --hud-progress-speed: .55s;
   --hud-progress-ease: linear;
+  --hud-ease: cubic-bezier(.22,1,.36,1);
   --hud-rail-gap: 14px;
   --hud-glow: .28;
   --hud-streak-fast: 1.75s;
@@ -94,12 +95,13 @@ body { overscroll-behavior: none; background: #000; -webkit-font-smoothing: anti
   position: absolute; inset: 0; contain: paint;
   background-image: var(--sigad-logo-url);
   background-repeat: no-repeat; background-position: center;
-  background-size: min(54vw, 820px) auto;
-  filter: blur(2.25px) saturate(.96);
-  opacity: .085; mix-blend-mode: screen;
+  background-size: clamp(420px, 58vw, 900px) auto;
+  filter: blur(1.8px) saturate(1.05) brightness(1.05);
+  opacity: .12; mix-blend-mode: screen;
+  transition: opacity .4s ease, filter .4s ease;
 }
-.bg-logo--light{ opacity:.06; filter: blur(1.6px) saturate(.9) contrast(1.05); mix-blend-mode: multiply; }
-.light .bg-logo{ opacity:.06; filter: blur(2px) saturate(.9); mix-blend-mode: multiply; }
+.bg-logo--light{ opacity:.085; filter: blur(1.4px) saturate(.95) contrast(1.08); mix-blend-mode: multiply; }
+.light .bg-logo{ opacity:.085; filter: blur(1.4px) saturate(.95) contrast(1.08); mix-blend-mode: multiply; }
 .light .orb{ opacity:.18; }
 .light .brand-shine{ filter: saturate(1.1); }
 
@@ -121,6 +123,20 @@ body { overscroll-behavior: none; background: #000; -webkit-font-smoothing: anti
 .orb--cyan   { width: 20rem; height: 20rem; left: 22%;   bottom: -6rem; background: radial-gradient(ellipse at center, #22d3ee 0%, transparent 60%); animation-delay: 6s; }
 .orb--soft{ opacity:.2; filter: blur(22px) saturate(.9); }
 @keyframes orbFloat { 0%,100% { transform: translate3d(0,0,0) } 50% { transform: translate3d(6px,-12px,0) } }
+
+/* ===== Bokeh flotante ===== */
+.hud-bokeh { position:absolute; inset:0; pointer-events:none; overflow:hidden; mix-blend-mode:screen; opacity:.55; }
+.hud-bokeh--light{ mix-blend-mode:multiply; opacity:.42; }
+.hud-bokeh__item { position:absolute; border-radius:9999px; filter: blur(22px); opacity:.48; transform-origin:center; animation: hudBokehDrift var(--dur,18s) ease-in-out infinite; }
+.light .hud-bokeh__item{ filter: blur(18px); opacity:.36; }
+.hud-bokeh__item--1{ --dur:19s; width:24rem; height:24rem; top:8%; left:14%; background: radial-gradient(circle at 35% 35%, rgba(99,102,241,.55), rgba(14,165,233,.12) 60%, transparent 76%); }
+.hud-bokeh__item--2{ --dur:23s; width:20rem; height:20rem; top:16%; right:12%; background: radial-gradient(circle at 70% 20%, rgba(236,72,153,.52), rgba(244,114,182,.18) 60%, transparent 78%); }
+.hud-bokeh__item--3{ --dur:21s; width:18rem; height:18rem; bottom:12%; left:26%; background: radial-gradient(circle at 30% 60%, rgba(14,165,233,.52), rgba(56,189,248,.12) 62%, transparent 80%); }
+.hud-bokeh__item--4{ --dur:25s; width:22rem; height:22rem; bottom:8%; right:18%; background: radial-gradient(circle at 60% 60%, rgba(168,85,247,.5), rgba(99,102,241,.16) 65%, transparent 80%); }
+.hud-bokeh__item--5{ --dur:17s; width:16rem; height:16rem; top:42%; left:-6rem; background: radial-gradient(circle at 40% 40%, rgba(16,185,129,.45), rgba(34,197,94,.12) 60%, transparent 80%); }
+.hud-bokeh__item--6{ --dur:22s; width:18rem; height:18rem; top:-6%; right:30%; background: radial-gradient(circle at 50% 30%, rgba(59,130,246,.5), rgba(129,140,248,.18) 65%, transparent 80%); }
+.hud-bokeh__item--7{ --dur:20s; width:20rem; height:20rem; bottom:-10%; left:48%; background: radial-gradient(circle at 50% 70%, rgba(56,189,248,.45), rgba(16,185,129,.18) 60%, transparent 80%); }
+@keyframes hudBokehDrift{ 0%,100%{ transform: translate3d(0,0,0) scale(1); } 50%{ transform: translate3d(14px,-18px,0) scale(1.05); } }
 
 /* ===== Vignette + rieles ===== */
 .vignette::after {
@@ -145,6 +161,56 @@ body { overscroll-behavior: none; background: #000; -webkit-font-smoothing: anti
 .light .status-ping{ opacity:.55; }
 @keyframes uxPing{ 0%{ transform: scale(.6); opacity:.65; } 80%{ transform: scale(var(--status-ping-scale)); opacity:0; } 100%{ transform: scale(var(--status-ping-scale)); opacity:0; } }
 .hud-topbar .status-ping, .hud-frame .status-ping{ animation: uxPing 1.8s cubic-bezier(0,0,.2,1) infinite; }
+
+/* ===== Densidad HUD (compacto / expandido) ===== */
+.hud-frame--compact{ padding:1.6rem 1.55rem !important; border-radius:22px !important; }
+@media (min-width: 768px){ .hud-frame--compact{ padding:2.05rem 2.1rem !important; } }
+.hud-frame--expanded{ padding:2.5rem 2.45rem !important; border-radius:30px !important; }
+@media (min-width: 768px){ .hud-frame--expanded{ padding:3rem 3rem !important; } }
+.hud-columns{ display:grid; gap:1.25rem; align-items:start; grid-template-columns:minmax(0,1fr); }
+.hud-columns> *{ min-width:0; }
+.hud-columns--compact{ gap:0.9rem; }
+.hud-columns--expanded{ gap:1.8rem; }
+.hud-side-stack{ display:flex; flex-direction:column; gap:1.2rem; align-items:stretch; }
+.hud-side-stack> *{ min-width:0; }
+.hud-side-stack--compact{ gap:0.9rem; }
+.hud-side-stack--expanded{ gap:1.7rem; }
+.hud-frame{ transform-origin: top center; transition: transform .6s var(--hud-ease); will-change: transform; margin-bottom: clamp(0px, calc(var(--hud-zoom-extra, 0) * 45vh), 320px); }
+.hud-info-grid{ display:grid; gap:1.1rem; align-items:stretch; }
+.hud-info-grid--compact{ gap:0.85rem; }
+.hud-info-grid--expanded{ gap:1.6rem; }
+.hud-info-grid--single{ grid-template-columns:minmax(0,1fr); }
+.hud-info-grid__cell{ min-width:0; display:flex; transition: transform .6s var(--hud-ease), opacity .6s var(--hud-ease); will-change: transform, opacity; }
+.hud-info-grid__cell> *{ flex:1; }
+@media (min-width: 1280px){
+  .hud-columns{ grid-template-columns:minmax(0,1.12fr) minmax(0,0.88fr); }
+  .hud-columns--compact{ grid-template-columns:minmax(0,1.2fr) minmax(0,0.8fr); }
+  .hud-columns--expanded{ grid-template-columns:minmax(0,1fr) minmax(0,1fr); }
+  .hud-side-stack{ gap:1.35rem; }
+  .hud-side-stack--compact{ gap:1rem; }
+  .hud-side-stack--expanded{ gap:1.85rem; }
+  .hud-info-grid{ grid-template-columns:repeat(2,minmax(0,1fr)); }
+  .hud-info-grid--compact{ gap:0.8rem; }
+  .hud-info-grid--expanded{ gap:1.75rem; }
+  .hud-info-grid--single{ grid-template-columns:minmax(0,1fr); }
+}
+.hud-config-menu{ position:absolute; top:calc(100% + 6px); right:0; width:240px; padding:0.85rem; border-radius:12px; background:#11141a; border:1px solid rgba(148,163,184,.38); color:#e5e7eb; z-index:50; box-shadow:0 18px 40px rgba(15,23,42,.35); }
+.hud-config-menu::before{ content:""; position:absolute; top:-7px; right:24px; border:7px solid transparent; border-bottom-color:rgba(148,163,184,.38); }
+.hud-config-menu::after{ content:""; position:absolute; top:-6px; right:24px; border:7px solid transparent; border-bottom-color:#11141a; }
+.hud-config-menu__section{ margin-bottom:0.75rem; }
+.hud-config-menu__section:last-child{ margin-bottom:0.5rem; }
+.hud-config-menu__label{ font-size:0.7rem; font-weight:600; letter-spacing:.08em; text-transform:uppercase; color:rgba(226,232,240,.75); margin-bottom:0.4rem; }
+.hud-config-menu__slider{ width:100%; accent-color:#6366f1; }
+.hud-config-menu .btn-link{ color:inherit; opacity:.6; }
+.hud-config-menu .btn-link:hover{ opacity:1; }
+.hud-config-menu .btn-outline-secondary.active,
+.hud-config-menu .btn-secondary{ color:#fff; }
+.light .hud-config-menu{ background:rgba(255,255,255,.94); color:#0f172a; border-color:rgba(148,163,184,.45); box-shadow:0 18px 40px rgba(15,23,42,.15); }
+.light .hud-config-menu::after{ border-bottom-color:rgba(255,255,255,.94); }
+.light .hud-config-menu__label{ color:rgba(30,41,59,.7); }
+.light .hud-config-menu .btn-link{ color:#0f172a; }
+.hud-density-compact .ux-header{ margin-bottom:1.4rem !important; }
+.hud-density-expanded .ux-header{ margin-bottom:2.3rem !important; }
 
 /* ===== Ribbon / brand shine ===== */
 .ribbon { position:relative; overflow:hidden; }
@@ -177,65 +243,171 @@ body { overscroll-behavior: none; background: #000; -webkit-font-smoothing: anti
 .digit-glow{ text-shadow: 0 0 12px rgba(255,255,255,.22), 0 0 24px rgba(99,102,241,.16); }
 
 /* =========================================================
-   PROGRESO: barra “ultra pro”
+   PROGRESO: panel + barra holográfica
    ========================================================= */
-.neon-progress{
+.progress-panel{
+  --progress: 0;
+  --accent-start: var(--accent-1);
+  --accent-mid: var(--accent-2);
+  --accent-end: #a855f7;
   position: relative;
-  box-shadow: inset 0 0 0 1px rgba(255,255,255,.06), 0 0 16px rgba(99,102,241,.14);
-  isolation: isolate; overflow: visible; background-color: color-mix(in srgb, var(--surface-2), transparent 10%);
+  padding: 26px 28px 28px;
+  border-radius: 26px;
+  border: 1px solid color-mix(in srgb, var(--border-1), transparent 35%);
+  background: linear-gradient(155deg, color-mix(in srgb, var(--surface-1), transparent 6%) 0%, color-mix(in srgb, var(--surface-2), transparent 18%) 55%, rgba(255,255,255,.02) 100%);
+  box-shadow: 0 28px 54px rgba(8,8,12,.46);
+  display:flex;
+  flex-direction:column;
+  gap:22px;
+  overflow:hidden;
+  isolation:isolate;
+  transition: transform .6s var(--hud-ease), box-shadow .6s var(--hud-ease), opacity .6s var(--hud-ease);
 }
-.light .neon-progress{ box-shadow: inset 0 0 0 1px rgba(0,0,0,.06), 0 0 12px rgba(99,102,241,.10); }
-.neon-progress::before{
-  content:""; position:absolute; inset:0; border-radius:9999px; pointer-events:none;
-  background:
-    linear-gradient(to right, rgba(255,255,255,.06), rgba(255,255,255,0)) border-box,
-    repeating-linear-gradient(90deg, rgba(255,255,255,.06) 0 1px, transparent 1px var(--hud-rail-gap));
-  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
-  mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
-  -webkit-mask-composite: xor; mask-composite: exclude; padding: 1px; opacity:.35;
+.light .progress-panel{ 
+  background: linear-gradient(155deg, rgba(255,255,255,.94) 0%, rgba(248,250,252,.86) 55%, rgba(244,244,245,.78) 100%);
+  border-color: rgba(15,23,42,.08);
+  box-shadow: 0 26px 40px rgba(15,23,42,.18);
 }
-.neon-progress::after{
-  content:""; position:absolute; inset:-8px -10px; border-radius:9999px; pointer-events:none;
-  background: radial-gradient(50% 60% at 0% 50%, rgba(255,255,255,.12), transparent 60%);
-  mix-blend-mode: screen; filter: blur(12px); opacity: var(--hud-glow);
-  transform: translateX(calc(var(--p,0) * 1%)); transition: transform var(--hud-progress-speed) var(--hud-progress-ease);
+.progress-panel--compact{ padding:20px 22px 22px; border-radius:22px; gap:18px; }
+.progress-panel--compact .progress-panel__header{ gap:14px; }
+.progress-panel--compact .progress-panel__icon{ width:46px; height:46px; border-radius:16px; box-shadow: 0 16px 30px color-mix(in srgb, var(--accent-mid), transparent 55%); }
+.progress-panel--compact .progress-panel__chip{ padding:8px 12px; border-radius:14px; gap:8px; }
+.progress-panel--compact .progress-panel__chipIcon{ width:22px; height:22px; border-radius:9px; }
+.progress-panel--compact .progress-panel__title{ font-size:1.16rem; }
+.progress-panel--compact .progress-panel__legend{ gap:14px; }
+.progress-panel--compact .progress-panel__fact strong{ font-size:.95rem; }
+.progress-panel--compact .progress-panel__fact small{ font-size:.68rem; letter-spacing:.26em; }
+.progress-panel--expanded{ padding:32px 34px 34px; border-radius:30px; gap:28px; }
+.progress-panel--expanded .progress-panel__icon{ width:60px; height:60px; border-radius:20px; box-shadow: 0 26px 48px color-mix(in srgb, var(--accent-mid), transparent 45%); }
+.progress-panel--expanded .progress-panel__chip{ padding:12px 18px; border-radius:18px; gap:12px; }
+.progress-panel--expanded .progress-panel__chipIcon{ width:30px; height:30px; }
+.progress-panel--expanded .progress-panel__title{ font-size:1.45rem; }
+.progress-panel::after{ 
+  content:""; position:absolute; inset:12px; border-radius:24px; pointer-events:none;
+  border:1px solid rgba(255,255,255,.04); opacity:.45; mix-blend-mode: screen;
 }
-
-.progress-stripes{
-  background-image:
-    linear-gradient(90deg, rgba(255,255,255,.13) 25%, transparent 25%, transparent 50%, rgba(255,255,255,.13) 50%, rgba(255,255,255,.13) 75%, transparent 75%, transparent),
-    linear-gradient(to right, var(--c1, var(--accent-1)), var(--c2, var(--accent-2)));
-  background-size: 28px 100%, 100% 100%; background-repeat: repeat, no-repeat; animation: stripes .9s linear infinite;
+.light .progress-panel::after{ border-color: rgba(15,23,42,.08); opacity:.35; mix-blend-mode: multiply; }
+.progress-panel__halo{
+  position:absolute; inset:-40% -50% auto -30%; height:72%;
+  background: radial-gradient(circle at 20% 30%, color-mix(in srgb, var(--accent-mid), transparent 40%), transparent 70%);
+  filter: blur(10px); opacity:.55;
 }
-.neon-progress .progress-stripes{ transition: width var(--hud-progress-speed) var(--hud-progress-ease); will-change: width; }
-@keyframes stripes { from { background-position: 0 0, 0 0; } to { background-position: 28px 0, 0 0; } }
+.light .progress-panel__halo{ opacity:.35; filter: blur(18px) saturate(.9); }
+.progress-panel__header{ position:relative; z-index:1; display:flex; align-items:center; gap:18px; }
+.progress-panel__icon{
+  width:54px; height:54px; border-radius:18px; display:inline-flex; align-items:center; justify-content:center;
+  background: linear-gradient(135deg, color-mix(in srgb, var(--accent-start), transparent 0%), color-mix(in srgb, var(--accent-mid), transparent 0%));
+  color:#fff; box-shadow: 0 20px 42px color-mix(in srgb, var(--accent-mid), transparent 55%);
+}
+.light .progress-panel__icon{ box-shadow: 0 20px 36px color-mix(in srgb, var(--accent-mid), transparent 45%); }
+.progress-panel__subtitle{ font-size:.68rem; letter-spacing:.32em; text-transform:uppercase; color: var(--text-3); }
+.progress-panel__title{ font-size:1.32rem; font-weight:700; letter-spacing:-.01em; color: var(--text-1); margin-top:4px; }
+.progress-panel__chip{
+  margin-left:auto; display:inline-flex; align-items:center; gap:10px; padding:10px 14px; border-radius:16px;
+  border:1px solid color-mix(in srgb, var(--accent-mid), transparent 60%);
+  background: color-mix(in srgb, var(--accent-start), transparent 75%);
+  color: var(--text-1); box-shadow: 0 18px 38px color-mix(in srgb, var(--accent-mid), transparent 45%);
+  backdrop-filter: blur(14px);
+}
+.light .progress-panel__chip{
+  color: color-mix(in srgb, var(--accent-mid), black 18%);
+  background: color-mix(in srgb, var(--accent-start), rgba(255,255,255,.78) 52%);
+  border-color: color-mix(in srgb, var(--accent-mid), transparent 70%);
+}
+.progress-panel__chipIcon{
+  display:inline-flex; align-items:center; justify-content:center; width:26px; height:26px; border-radius:10px;
+  background: linear-gradient(135deg, color-mix(in srgb, var(--accent-start), transparent 20%), color-mix(in srgb, var(--accent-end), transparent 10%));
+  color:#fff; box-shadow: 0 12px 26px color-mix(in srgb, var(--accent-mid), transparent 55%);
+}
+.progress-panel__chipMeta{ display:flex; flex-direction:column; align-items:flex-end; line-height:1; }
+.progress-panel__chipValue{ font-size:1.45rem; font-weight:800; letter-spacing:-.02em; }
+.progress-panel__chipValue sup{ font-size:.7rem; margin-left:1px; }
+.progress-panel__chipLabel{ font-size:.62rem; letter-spacing:.34em; text-transform:uppercase; opacity:.75; }
+.progress-panel__meter{ position:relative; z-index:1; }
+.progress-beam{
+  position:relative; height:18px; border-radius:999px; overflow:hidden;
+  background: linear-gradient(180deg, rgba(255,255,255,.1), rgba(255,255,255,.02));
+  border:1px solid color-mix(in srgb, var(--border-1), transparent 40%);
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,.06);
+}
+.light .progress-beam{
+  background: linear-gradient(180deg, rgba(15,23,42,.08), rgba(15,23,42,.02));
+  border-color: rgba(15,23,42,.12);
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,.65);
+}
+.progress-beam__fill{
+  position:absolute; inset:0; width:100%;
+  transform-origin:left center;
+  transform: scaleX(var(--progress-ratio, 0));
+  background: linear-gradient(120deg, var(--accent-start), var(--accent-mid), var(--accent-end));
+  border-radius:inherit; box-shadow: 0 0 36px color-mix(in srgb, var(--accent-mid), transparent 35%);
+  transition: transform var(--hud-progress-speed) var(--hud-progress-ease);
+  will-change: transform;
+}
+.progress-beam__glow{
+  position:absolute; inset:-30% -60%; pointer-events:none;
+  background: radial-gradient(55% 70% at 0% 50%, color-mix(in srgb, var(--accent-end), transparent 40%), transparent 70%);
+  opacity:.65; transform: translateX(calc(var(--progress-ratio, 0) * 100%));
+  transition: transform var(--hud-progress-speed) var(--hud-progress-ease);
+}
+.progress-beam__spark{
+  position:absolute; top:-16px; bottom:-16px; left:0; width:120px; pointer-events:none;
+  transform: translateX(calc(var(--progress-ratio, 0) * 100% - 60px));
+  background: radial-gradient(60px 60px at 20% 50%, rgba(255,255,255,.3), transparent 60%), radial-gradient(120px 120px at 0% 50%, color-mix(in srgb, var(--accent-end), transparent 15%), transparent 70%);
+  mix-blend-mode: screen; opacity:.75; filter: blur(6px);
+  transition: transform var(--hud-progress-speed) var(--hud-progress-ease);
+}
+.progress-beam__shine{
+  position:absolute; inset:-12px -20px; pointer-events:none;
+  background: linear-gradient(120deg, rgba(255,255,255,.35), transparent 45%);
+  mix-blend-mode: screen; opacity:.35;
+  transform: translateX(calc(var(--progress-ratio, 0) * 100% - 20px));
+  transition: transform var(--hud-progress-speed) var(--hud-progress-ease);
+}
+.progress-beam--static .progress-beam__fill,
+.progress-beam--static .progress-beam__glow,
+.progress-beam--static .progress-beam__spark,
+.progress-beam--static .progress-beam__shine{ transition: none !important; }
+.progress-panel__scale{ position:absolute; inset:0; pointer-events:none; }
+.progress-panel__tick{
+  position:absolute; top:-6px; width:2px; height:30px; border-radius:999px;
+  background: color-mix(in srgb, var(--border-1), transparent 20%); opacity:.55;
+}
+.light .progress-panel__tick{ background: color-mix(in srgb, var(--border-1), transparent 30%); opacity:.65; }
+.progress-panel__legend{ position:relative; z-index:1; display:grid; gap:18px; }
+@media (min-width:768px){
+  .progress-panel__legend{ grid-template-columns: repeat(3, minmax(0,1fr)); }
+  .progress-panel__fact--wide{ grid-column: span 2; }
+}
+.progress-panel__fact{
+  display:flex; align-items:flex-start; gap:12px; padding:12px 14px;
+  border-radius:16px; background: color-mix(in srgb, var(--surface-2), transparent 30%);
+  border:1px solid color-mix(in srgb, var(--border-1), transparent 45%);
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,.04);
+  color: var(--text-2);
+}
+.light .progress-panel__fact{
+  background: rgba(255,255,255,.85);
+  border:1px solid rgba(15,23,42,.08);
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,.55);
+  color: color-mix(in srgb, var(--text-2), black 12%);
+}
+.progress-panel__factIcon{
+  display:inline-flex; align-items:center; justify-content:center;
+  width:32px; height:32px; border-radius:12px;
+  background: color-mix(in srgb, var(--accent-start), transparent 80%);
+  color: color-mix(in srgb, var(--accent-mid), transparent 20%);
+}
+.progress-panel__fact strong{
+  display:block; font-size:1.02rem; font-weight:600; letter-spacing:-.01em; color: var(--text-1);
+}
+.progress-panel__fact small{
+  display:block; margin-top:6px; font-size:.64rem; letter-spacing:.32em; text-transform:uppercase; color: var(--text-3);
+}
+.progress-panel__fact--wide strong{ color: color-mix(in srgb, var(--accent-mid), var(--text-1) 40%); }
 
 .transition-width{ transition: width var(--hud-progress-speed) var(--hud-progress-ease) !important; }
 .no-transition{ transition: none !important; }
-
-.progress-fill{ position: relative; overflow: hidden; border-radius:9999px; }
-.progress-fill::before,
-.progress-fill::after{ content:""; position:absolute; inset:-8px 0; pointer-events:none; mix-blend-mode: screen; filter: blur(7px); }
-.progress-fill::before{ background: linear-gradient(115deg, rgba(255,255,255,0) 0%, rgba(255,255,255,.45) 10%, rgba(255,255,255,0) 22%) no-repeat; background-size: 170px 100%; animation: streakSlow var(--hud-streak-slow) linear infinite; opacity:.42; }
-.progress-fill::after{
-  background:
-    linear-gradient(115deg, rgba(255,255,255,0) 0%, rgba(255,255,255,.78) 12%, rgba(255,255,255,0) 24%) no-repeat,
-    radial-gradient(2px 2px at 12% 38%, rgba(255,255,255,.6), transparent 60%),
-    radial-gradient(2px 2px at 28% 62%, rgba(255,255,255,.45), transparent 60%),
-    radial-gradient(2px 2px at 44% 41%, rgba(255,255,255,.55), transparent 60%),
-    radial-gradient(2px 2px at 60% 58%, rgba(255,255,255,.35), transparent 60%),
-    radial-gradient(2px 2px at 76% 50%, rgba(255,255,255,.5), transparent 60%),
-    radial-gradient(60px 60px at 16% 50%, rgba(255,255,255,.26), transparent 60%);
-  background-size: 130px 100%, 160px 100%, 160px 100%, 160px 100%, 160px 100%, 160px 100%, 180px 100%;
-  background-position: 0 0, 0 0, 40px 0, 80px 0, 120px 0, 160px 0, 0 0; animation: streakFast var(--hud-streak-fast) linear infinite, bokehFlow var(--hud-bokeh-speed) linear infinite; opacity:.58;
-}
-@keyframes streakSlow{ from { background-position: -170px 0; } to { background-position: calc(100% + 170px) 0; } }
-@keyframes streakFast{ from { background-position: -130px 0, 0 0, 40px 0, 80px 0, 120px 0, 160px 0, 0 0; } to { background-position: calc(100% + 130px) 0, 200px 0, 240px 0, 280px 0, 320px 0, 360px 0, 200px 0; } }
-@keyframes bokehFlow{ from { filter: blur(7px); } 50% { filter: blur(6px); } to { filter: blur(7px); } }
-
-.progress-comet{ position:absolute; top:-7px; bottom:-7px; left:0; width:140px; pointer-events:none; transform: translateX(calc((var(--p, 0) * 1%) - 70px)); background: radial-gradient(60px 60px at 10% 50%, rgba(255,255,255,.28), transparent 60%), radial-gradient(120px 120px at 0% 50%, currentColor, transparent 72%); filter: blur(7px); opacity:.65; mix-blend-mode: screen; }
-.progress-tip{ position:absolute; top:-2px; bottom:-2px; left:0; width:18px; pointer-events:none; transform: translateX(calc((var(--p, 0) * 1%) - 9px)); background: radial-gradient(10px 10px at 50% 50%, rgba(255,255,255,.9), rgba(255,255,255,.2) 60%, transparent 70%); filter: blur(0.5px); opacity:.85; mix-blend-mode: screen; }
-.progress-edge{ position:absolute; top:-3px; bottom:-3px; left:0; width:2px; pointer-events:none; transform: translateX(calc((var(--p, 0) * 1%) - 1px)); background: linear-gradient(to bottom, rgba(255,255,255,0), rgba(255,255,255,.9), rgba(255,255,255,0)), linear-gradient(to bottom, color-mix(in srgb, var(--accent-1), transparent 0%), color-mix(in srgb, var(--accent-2), transparent 0%)); filter: drop-shadow(0 0 6px var(--accent-2)) drop-shadow(0 0 12px var(--accent-1)); mix-blend-mode: screen; opacity:.9; }
 
 /* ===== Flip tick números ===== */
 .animate-flipTick{ animation: flipTick 260ms ease-out; }
@@ -258,6 +430,223 @@ body { overscroll-behavior: none; background: #000; -webkit-font-smoothing: anti
 .light .hud-frame::after{ box-shadow: inset 0 0 50px rgba(99,102,241,.04); }
 .sweep::before{ content:""; position:absolute; inset:0; pointer-events:none; border-radius:1.5rem; background: linear-gradient(115deg, transparent 40%, rgba(255,255,255,.06) 50%, transparent 60%); animation: sweep 6.8s linear infinite; }
 @keyframes sweep { to { background-position: 200% 0; } }
+
+/* ===== Round track ===== */
+.round-track{ position:relative; border-radius:22px; padding:18px 22px 22px; border:1px solid color-mix(in srgb, var(--border-1), transparent 10%); background: radial-gradient(140% 120% at 14% -18%, color-mix(in srgb, var(--accent-2), transparent 74%), transparent 70%), radial-gradient(120% 130% at 90% 0%, color-mix(in srgb, var(--accent-1), transparent 78%), transparent 72%), linear-gradient(162deg, color-mix(in srgb, var(--surface-1), transparent 18%), color-mix(in srgb, var(--surface-2), transparent 4%)); backdrop-filter: blur(26px); box-shadow: 0 22px 48px rgba(15,23,42,.32); overflow:hidden; isolation:isolate; max-width:100%; transition: transform .6s var(--hud-ease), box-shadow .6s var(--hud-ease), opacity .6s var(--hud-ease); }
+.light .round-track{ border-color: rgba(148,163,184,.22); background: radial-gradient(140% 120% at 14% -16%, rgba(167,139,250,.28), transparent 70%), radial-gradient(120% 130% at 88% 4%, rgba(59,130,246,.22), transparent 72%), linear-gradient(162deg, rgba(255,255,255,.94), rgba(244,249,255,.86)); box-shadow: 0 18px 36px rgba(15,23,42,.12); }
+.round-track::before,
+.round-track::after{ content:""; position:absolute; inset:0; pointer-events:none; border-radius:inherit; transition: opacity .6s var(--hud-ease); }
+.round-track::before{ background: radial-gradient(120% 140% at 22% 0%, rgba(255,255,255,.18), transparent 65%); opacity:.42; mix-blend-mode:screen; }
+.round-track::after{ background: radial-gradient(120% 120% at 80% 110%, rgba(56,189,248,.26), transparent 72%); opacity:.32; mix-blend-mode:screen; }
+.light .round-track::before{ opacity:.55; mix-blend-mode:soft-light; }
+.light .round-track::after{ opacity:.25; mix-blend-mode:multiply; }
+.round-track--break{ background: radial-gradient(140% 120% at 14% -16%, rgba(253,220,148,.32), transparent 70%), radial-gradient(120% 130% at 90% 6%, rgba(253,164,175,.28), transparent 74%), linear-gradient(162deg, color-mix(in srgb, var(--surface-1), transparent 14%), color-mix(in srgb, var(--surface-2), transparent 6%)); }
+.light .round-track--break{ background: radial-gradient(140% 120% at 14% -16%, rgba(253,213,141,.45), transparent 70%), radial-gradient(120% 130% at 90% 6%, rgba(248,196,150,.38), transparent 74%), linear-gradient(162deg, rgba(255,255,255,.94), rgba(253,250,243,.88)); }
+.round-track--break::after{ background: radial-gradient(120% 120% at 80% 110%, rgba(253,186,116,.38), transparent 72%); }
+.round-track__header{ position:relative; z-index:2; display:flex; align-items:flex-start; gap:14px; margin-bottom:12px; }
+.round-track__icon{ display:inline-flex; align-items:center; justify-content:center; width:40px; height:40px; border-radius:14px; background: linear-gradient(135deg, rgba(59,130,246,.6), rgba(129,140,248,.6)); color:#fff; box-shadow: 0 12px 28px rgba(59,130,246,.28); }
+.round-track--break .round-track__icon{ background: linear-gradient(135deg, rgba(251,191,36,.7), rgba(248,113,113,.6)); box-shadow: 0 12px 28px rgba(251,191,36,.28); }
+.round-track__subtitle{ font-size:.64rem; letter-spacing:.32em; text-transform:uppercase; color: var(--text-3); }
+.round-track__title{ font-size:1.05rem; font-weight:700; color: var(--text-1); letter-spacing:-.01em; }
+.round-track__meta{ margin-left:auto; font-size:.7rem; letter-spacing:.16em; text-transform:uppercase; color: var(--text-3); display:flex; align-items:center; gap:6px; padding:4px 10px; border-radius:999px; background: color-mix(in srgb, var(--surface-2), transparent 20%); box-shadow: inset 0 0 0 1px rgba(255,255,255,.05); }
+.light .round-track__meta{ background: rgba(255,255,255,.78); box-shadow: inset 0 0 0 1px rgba(15,23,42,.08); color: color-mix(in srgb, var(--text-3), black 18%); }
+.round-track__bar{ position:relative; z-index:2; height:6px; border-radius:999px; background: color-mix(in srgb, var(--surface-2), transparent 32%); box-shadow: inset 0 0 0 1px rgba(255,255,255,.05); overflow:hidden; margin-bottom:14px; }
+.light .round-track__bar{ background: rgba(15,23,42,.08); box-shadow: inset 0 0 0 1px rgba(15,23,42,.08); }
+.round-track__bar-fill{ position:absolute; inset:0; width:0; background: linear-gradient(90deg, rgba(129,140,248,.85), rgba(56,189,248,.85)); box-shadow: 0 12px 26px rgba(56,189,248,.25); border-radius:inherit; transition: width .6s var(--hud-ease); }
+.round-track--break .round-track__bar-fill{ background: linear-gradient(90deg, rgba(251,191,36,.85), rgba(248,113,113,.85)); box-shadow: 0 12px 24px rgba(251,191,36,.28); }
+.round-track__rail{ position:relative; z-index:2; display:flex; align-items:center; gap:10px; flex-wrap:nowrap; overflow:hidden; }
+.round-track__ellipsis{ display:flex; align-items:center; justify-content:center; min-width:20px; color: var(--text-3); font-size:1.3rem; letter-spacing:.3em; }
+.round-track__node{ position:relative; flex:0 0 auto; min-width:34px; aspect-ratio:1 / 1; border-radius:999px; display:flex; align-items:center; justify-content:center; background: color-mix(in srgb, var(--surface-2), transparent 25%); color: var(--text-3); font-weight:600; letter-spacing:.02em; box-shadow: inset 0 0 0 1px rgba(255,255,255,.05); overflow:hidden; isolation:isolate; }
+.light .round-track__node{ background: rgba(255,255,255,.85); color: color-mix(in srgb, var(--text-3), black 12%); box-shadow: inset 0 0 0 1px rgba(15,23,42,.08); }
+.round-track__node::after{ content:""; position:absolute; top:50%; left:100%; width:22px; height:2px; background: linear-gradient(90deg, rgba(255,255,255,.28), transparent); transform: translateY(-50%); }
+.light .round-track__node::after{ background: linear-gradient(90deg, rgba(15,23,42,.22), transparent); }
+.round-track__node:last-child::after{ display:none; }
+.round-track__node--done{ background: linear-gradient(150deg, rgba(56,189,248,.58), rgba(99,102,241,.58)); color:#f8fafc; box-shadow: 0 12px 26px rgba(56,189,248,.28); }
+.round-track--break .round-track__node--done{ background: linear-gradient(150deg, rgba(251,191,36,.7), rgba(248,113,113,.65)); box-shadow: 0 12px 26px rgba(251,191,36,.24); }
+.round-track__node--now{ background: linear-gradient(150deg, rgba(168,85,247,.75), rgba(236,72,153,.78)); color:#fff; box-shadow: 0 14px 30px rgba(168,85,247,.32); }
+.round-track--break .round-track__node--now{ background: linear-gradient(150deg, rgba(251,191,36,.8), rgba(245,158,11,.72)); color:#fff8dc; box-shadow: 0 14px 30px rgba(251,191,36,.32); }
+.round-track__label{ position:relative; z-index:2; font-variant-numeric: tabular-nums; font-size:.78rem; }
+.round-track__spark{ position:absolute; inset:0; pointer-events:none; opacity:0; background: radial-gradient(100% 100% at 50% 50%, rgba(255,255,255,.55), transparent 70%); transition: opacity .4s ease; }
+.round-track__spark--active{ opacity:1; animation: roundSpark 1.8s ease-in-out infinite; }
+.round-track__spark--trail{ opacity:.45; }
+.round-track__caption{ position:relative; z-index:2; margin-top:16px; font-size:.82rem; line-height:1.55; color: var(--text-3); max-width:44ch; }
+.light .round-track__caption{ color: color-mix(in srgb, var(--text-3), black 15%); }
+.round-track--density-compact{ padding:16px 18px 18px; border-radius:20px; }
+.round-track--density-compact .round-track__header{ gap:10px; margin-bottom:9px; }
+.round-track--density-compact .round-track__subtitle{ letter-spacing:.24em; font-size:.6rem; }
+.round-track--density-compact .round-track__title{ font-size:.98rem; }
+.round-track--density-compact .round-track__meta{ font-size:.62rem; padding:3px 8px; letter-spacing:.12em; }
+.round-track--density-compact .round-track__bar{ margin-bottom:11px; }
+.round-track--density-compact .round-track__rail{ gap:8px; }
+.round-track--density-compact .round-track__caption{ margin-top:10px; font-size:.76rem; max-width:36ch; }
+.round-track--density-expanded{ padding:24px 30px 30px; border-radius:28px; }
+.round-track--density-expanded .round-track__header{ margin-bottom:16px; }
+.round-track--density-expanded .round-track__title{ font-size:1.16rem; }
+.round-track--hud{ padding-top:18px; }
+.round-track--hud.round-track--density-compact{ padding-top:15px; }
+.round-track--hud.round-track--density-expanded{ padding-top:26px; }
+.round-track--mini .round-track__icon{ width:32px; height:32px; border-radius:12px; box-shadow: 0 10px 22px rgba(59,130,246,.26); }
+.round-track--mini.round-track--break .round-track__icon{ box-shadow: 0 10px 22px rgba(251,191,36,.24); }
+.round-track--mini .round-track__node{ min-width:30px; }
+.round-track--mini .round-track__node::after{ width:16px; }
+.round-track--density-compact .round-track__meta{ box-shadow: inset 0 0 0 1px rgba(255,255,255,.05); }
+.round-track--crowded .round-track__rail{ flex-wrap:wrap; gap:8px 10px; }
+.round-track--crowded .round-track__node{ flex:0 1 36px !important; min-width:36px; }
+.round-track--crowded .round-track__node::after{ display:none; }
+.round-track--crowded .round-track__ellipsis{ display:none; }
+.round-track--panel{ background: color-mix(in srgb, var(--surface-2), transparent 18%); border-color: color-mix(in srgb, var(--border-1), transparent 32%); box-shadow: inset 0 0 0 1px rgba(255,255,255,.04); }
+.round-track--panel::before{ opacity:.32; }
+.round-track--panel::after{ opacity:.22; }
+.light .round-track--panel{ background: rgba(255,255,255,.85); border-color: rgba(148,163,184,.24); box-shadow: inset 0 0 0 1px rgba(15,23,42,.05); }
+.round-summary-panel--break .round-track--panel{ background: color-mix(in srgb, rgba(253,220,148,.42), transparent 52%); border-color: rgba(251,191,36,.3); }
+.round-track--panel .round-track__header{ margin-bottom:12px; }
+.round-track--panel.round-track--density-compact .round-track__header{ margin-bottom:10px; }
+
+/* ===== Resumen combinado de rondas + hitos ===== */
+.round-summary-panel{ position:relative; display:flex; flex-direction:column; gap:1.2rem; padding:22px 24px; border-radius:24px; border:1px solid color-mix(in srgb, var(--border-1), transparent 15%); background: radial-gradient(150% 140% at 12% -18%, color-mix(in srgb, var(--accent-2), transparent 82%), transparent 70%), radial-gradient(120% 140% at 88% 0%, color-mix(in srgb, var(--accent-1), transparent 84%), transparent 72%), linear-gradient(160deg, color-mix(in srgb, var(--surface-1), transparent 10%), color-mix(in srgb, var(--surface-2), transparent 4%)); box-shadow: 0 20px 44px rgba(15,23,42,.32); backdrop-filter: blur(26px); overflow:hidden; isolation:isolate; }
+.round-summary-panel::before,
+.round-summary-panel::after{ content:""; position:absolute; inset:0; pointer-events:none; border-radius:inherit; transition: opacity .6s var(--hud-ease); }
+.round-summary-panel::before{ background: radial-gradient(120% 140% at 20% 0%, rgba(255,255,255,.22), transparent 68%); opacity:.42; mix-blend-mode:screen; }
+.round-summary-panel::after{ background: radial-gradient(120% 120% at 86% 110%, rgba(56,189,248,.28), transparent 72%); opacity:.28; mix-blend-mode:screen; }
+.light .round-summary-panel{ background: radial-gradient(150% 140% at 12% -16%, rgba(167,139,250,.22), transparent 70%), radial-gradient(120% 140% at 90% 4%, rgba(59,130,246,.22), transparent 74%), linear-gradient(160deg, rgba(255,255,255,.94), rgba(244,249,255,.9)); border-color: rgba(148,163,184,.22); box-shadow: 0 18px 36px rgba(15,23,42,.12); }
+.light .round-summary-panel::before{ opacity:.48; mix-blend-mode:soft-light; }
+.light .round-summary-panel::after{ opacity:.22; mix-blend-mode:multiply; }
+.round-summary-panel--break{ background: radial-gradient(150% 140% at 12% -16%, rgba(253,220,148,.46), transparent 70%), radial-gradient(120% 140% at 90% 4%, rgba(248,196,150,.42), transparent 74%), linear-gradient(160deg, color-mix(in srgb, var(--surface-1), transparent 4%), color-mix(in srgb, var(--surface-2), transparent 2%)); border-color: rgba(251,191,36,.26); }
+.round-summary-panel--break::after{ background: radial-gradient(120% 120% at 86% 110%, rgba(251,191,36,.32), transparent 72%); }
+.light .round-summary-panel--break{ background: radial-gradient(150% 140% at 12% -16%, rgba(253,213,141,.55), transparent 68%), radial-gradient(120% 140% at 92% 6%, rgba(253,186,116,.5), transparent 74%), linear-gradient(160deg, rgba(255,255,255,.95), rgba(255,250,245,.9)); border-color: rgba(251,191,36,.34); }
+.round-summary-panel--compact{ padding:18px 20px; border-radius:20px; gap:0.95rem; }
+.round-summary-panel--expanded{ padding:28px 32px; border-radius:30px; gap:1.55rem; }
+.round-summary-panel__header{ position:relative; z-index:2; display:flex; align-items:flex-start; justify-content:space-between; gap:14px; }
+.round-summary-panel__eyebrow{ font-size:.68rem; letter-spacing:.32em; text-transform:uppercase; color: var(--text-3); }
+.round-summary-panel__title{ font-size:1.16rem; font-weight:700; color: var(--text-1); letter-spacing:-.01em; }
+.round-summary-panel--compact .round-summary-panel__title{ font-size:1.02rem; }
+.round-summary-panel--expanded .round-summary-panel__title{ font-size:1.24rem; }
+.round-summary-panel__meta{ margin-left:auto; font-size:.72rem; letter-spacing:.18em; text-transform:uppercase; color: var(--text-3); padding:5px 12px; border-radius:999px; background: color-mix(in srgb, var(--surface-2), transparent 18%); box-shadow: inset 0 0 0 1px rgba(255,255,255,.04); }
+.light .round-summary-panel__meta{ background: rgba(255,255,255,.82); box-shadow: inset 0 0 0 1px rgba(15,23,42,.08); color: color-mix(in srgb, var(--text-3), black 18%); }
+.round-summary-panel__highlight{ position:relative; z-index:2; display:flex; align-items:center; gap:16px; padding:14px 16px; border-radius:18px; background: color-mix(in srgb, var(--surface-2), transparent 20%); border:1px solid color-mix(in srgb, var(--border-1), transparent 38%); box-shadow: inset 0 0 0 1px rgba(255,255,255,.04); }
+.light .round-summary-panel__highlight{ background: rgba(255,255,255,.82); border-color: rgba(148,163,184,.24); box-shadow: inset 0 0 0 1px rgba(15,23,42,.05); }
+.round-summary-panel--break .round-summary-panel__highlight{ background: color-mix(in srgb, rgba(253,220,148,.5), transparent 60%); border-color: rgba(251,191,36,.32); }
+.round-summary-panel__badge{ display:inline-flex; align-items:center; justify-content:center; width:42px; height:42px; border-radius:14px; background: linear-gradient(135deg, rgba(59,130,246,.68), rgba(129,140,248,.68)); color:#fff; box-shadow: 0 12px 28px rgba(59,130,246,.28); }
+.round-summary-panel__badge--break{ background: linear-gradient(135deg, rgba(251,191,36,.78), rgba(248,113,113,.7)); box-shadow: 0 12px 26px rgba(251,191,36,.28); }
+.round-summary-panel__badge--final{ background: linear-gradient(135deg, rgba(251,191,36,.82), rgba(249,115,22,.68)); box-shadow: 0 12px 26px rgba(251,191,36,.3); }
+.round-summary-panel__highlight-body{ display:flex; flex-direction:column; gap:2px; min-width:0; }
+.round-summary-panel__highlight-label{ font-size:.6rem; letter-spacing:.28em; text-transform:uppercase; color: var(--text-3); }
+.round-summary-panel__highlight-title{ font-weight:600; font-size:1.04rem; color: var(--text-1); letter-spacing:-.01em; }
+.round-summary-panel__highlight-time{ font-size:.9rem; color: var(--text-2); letter-spacing:.04em; }
+.round-summary-panel--compact .round-summary-panel__highlight{ padding:12px 14px; border-radius:16px; }
+.round-summary-panel--compact .round-summary-panel__badge{ width:34px; height:34px; border-radius:12px; }
+.round-summary-panel--compact .round-summary-panel__highlight-title{ font-size:.96rem; }
+.round-summary-panel--expanded .round-summary-panel__highlight{ padding:18px 20px; border-radius:22px; }
+.round-summary-panel--expanded .round-summary-panel__badge{ width:48px; height:48px; border-radius:16px; }
+.round-summary-panel--expanded .round-summary-panel__highlight-title{ font-size:1.16rem; }
+.round-summary-panel__content{ position:relative; z-index:2; display:grid; gap:18px; }
+.round-summary-panel--compact .round-summary-panel__content{ gap:14px; }
+.round-summary-panel--expanded .round-summary-panel__content{ gap:24px; }
+.round-summary-panel__track{ min-width:0; }
+.round-summary-panel__schedule{ display:flex; flex-direction:column; gap:12px; min-width:0; }
+.round-summary-panel__list-label{ font-size:.64rem; letter-spacing:.28em; text-transform:uppercase; color: var(--text-3); }
+.round-summary-panel__list{ list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:10px; }
+.round-summary-panel__item{ display:flex; align-items:center; gap:12px; padding:10px 12px; border-radius:16px; background: color-mix(in srgb, var(--surface-2), transparent 20%); border:1px solid color-mix(in srgb, var(--border-1), transparent 42%); box-shadow: inset 0 0 0 1px rgba(255,255,255,.04); }
+.light .round-summary-panel__item{ background: rgba(255,255,255,.82); border-color: rgba(148,163,184,.24); box-shadow: inset 0 0 0 1px rgba(15,23,42,.05); }
+.round-summary-panel__item-icon{ display:inline-flex; align-items:center; justify-content:center; width:32px; height:32px; border-radius:12px; background: linear-gradient(135deg, rgba(59,130,246,.65), rgba(129,140,248,.65)); color:#fff; box-shadow: 0 10px 22px rgba(59,130,246,.24); }
+.round-summary-panel__item--break .round-summary-panel__item-icon{ background: linear-gradient(135deg, rgba(251,191,36,.74), rgba(248,113,113,.68)); box-shadow: 0 10px 20px rgba(251,191,36,.24); }
+.round-summary-panel__item--final .round-summary-panel__item-icon{ background: linear-gradient(135deg, rgba(251,191,36,.8), rgba(249,115,22,.66)); box-shadow: 0 10px 20px rgba(251,191,36,.28); }
+.round-summary-panel__item-body{ display:flex; flex-direction:column; gap:2px; min-width:0; }
+.round-summary-panel__item-label{ font-weight:600; font-size:.9rem; color: var(--text-1); letter-spacing:-.005em; }
+.round-summary-panel__item-time{ font-size:.82rem; color: var(--text-2); letter-spacing:.03em; }
+.round-summary-panel__empty{ font-size:.82rem; color: var(--text-3); line-height:1.55; }
+.light .round-summary-panel__empty{ color: color-mix(in srgb, var(--text-3), black 18%); }
+.round-summary-panel--compact .round-summary-panel__item{ padding:8px 10px; border-radius:14px; }
+.round-summary-panel--compact .round-summary-panel__item-icon{ width:28px; height:28px; border-radius:11px; }
+.round-summary-panel--compact .round-summary-panel__item-label{ font-size:.84rem; }
+.round-summary-panel--expanded .round-summary-panel__item{ padding:12px 16px; border-radius:18px; }
+.round-summary-panel--expanded .round-summary-panel__item-icon{ width:38px; height:38px; border-radius:14px; }
+.round-summary-panel--expanded .round-summary-panel__item-label{ font-size:.98rem; }
+.round-summary-panel--expanded .round-summary-panel__item-time{ font-size:.88rem; }
+.round-summary-panel__schedule:empty{ display:none; }
+@media (min-width: 1024px){
+  .round-summary-panel__content{ grid-template-columns:minmax(0,0.58fr) minmax(0,0.42fr); align-items:start; }
+  .round-summary-panel__schedule{ padding-left:4px; }
+}
+@keyframes roundSpark{ 0%,100%{ transform: scale(.92); opacity:.55; } 50%{ transform: scale(1.05); opacity:.95; } }
+
+/* ===== Schedule card ===== */
+.schedule-card{ position:relative; overflow:hidden; border-radius:1.5rem; isolation:isolate; max-width:100%; transition: transform .6s var(--hud-ease), box-shadow .6s var(--hud-ease), opacity .6s var(--hud-ease); }
+.schedule-card--hud{ padding:22px; border-radius:22px; border:1px solid color-mix(in srgb, var(--border-1), transparent 12%); background: radial-gradient(150% 120% at 10% -18%, color-mix(in srgb, var(--accent-2), transparent 78%), transparent 72%), radial-gradient(130% 120% at 94% 6%, color-mix(in srgb, var(--accent-1), transparent 78%), transparent 74%), linear-gradient(158deg, color-mix(in srgb, var(--surface-1), transparent 16%), color-mix(in srgb, var(--surface-2), transparent 6%)); backdrop-filter: blur(26px); box-shadow: 0 20px 44px rgba(15,23,42,.32); }
+.light .schedule-card--hud{ background: radial-gradient(150% 120% at 10% -16%, rgba(167,139,250,.26), transparent 72%), radial-gradient(130% 120% at 94% 8%, rgba(59,130,246,.24), transparent 74%), linear-gradient(158deg, rgba(255,255,255,.94), rgba(245,248,255,.86)); border-color: rgba(148,163,184,.22); box-shadow: 0 18px 34px rgba(15,23,42,.12); }
+.hud-columns .schedule-card{ justify-self:stretch; }
+.hud-columns.hud-columns--compact .schedule-card{ max-width:min(100%,380px); }
+.hud-columns.hud-columns--expanded .schedule-card{ max-width:min(100%,460px); }
+.simple-panel__details{ border:1px solid rgba(148,163,184,.18); border-radius:12px; padding:0.5rem 0.75rem; background:rgba(15,23,42,.35); color:inherit; }
+.simple-panel__details summary{ cursor:pointer; list-style:none; font-weight:600; font-size:0.82rem; letter-spacing:.04em; text-transform:uppercase; color:rgba(226,232,240,.75); }
+.simple-panel__details summary::-webkit-details-marker{ display:none; }
+.simple-panel__details[open]{ background:rgba(148,163,184,.16); }
+.simple-panel__details > *:last-child{ margin-bottom:0; }
+.light .simple-panel__details{ background:rgba(255,255,255,.86); border-color:rgba(148,163,184,.45); }
+.light .simple-panel__details[open]{ background:rgba(255,255,255,.95); }
+.light .simple-panel__details summary{ color:rgba(15,23,42,.7); }
+.schedule-card::before{ content:""; position:absolute; inset:-30% -16%; border-radius:inherit; pointer-events:none; background: radial-gradient(120% 120% at 18% 0%, rgba(129,140,248,.32), transparent 72%); opacity:.32; mix-blend-mode:screen; transition: opacity .6s var(--hud-ease); }
+.schedule-card::after{ content:""; position:absolute; inset:-34% -18%; border-radius:inherit; pointer-events:none; background: radial-gradient(120% 110% at 84% 6%, rgba(236,72,153,.26), transparent 74%); opacity:.26; mix-blend-mode:screen; transition: opacity .6s var(--hud-ease); }
+.light .schedule-card::before{ opacity:.26; mix-blend-mode:multiply; }
+.light .schedule-card::after{ opacity:.2; mix-blend-mode:multiply; }
+.schedule-card__header{ position:relative; z-index:1; display:flex; align-items:center; justify-content:space-between; gap:12px; margin-bottom:12px; }
+.schedule-card__subtitle{ font-size:.72rem; letter-spacing:.32em; text-transform:uppercase; color: var(--text-3); }
+.schedule-card__hint{ font-size:.7rem; color: var(--text-3); opacity:.75; }
+.light .schedule-card__hint{ color: color-mix(in srgb, var(--text-3), black 15%); }
+.schedule-card__list{ position:relative; z-index:1; display:flex; flex-wrap:wrap; gap:12px; }
+.schedule-chip{ position:relative; display:flex; align-items:center; gap:10px; padding:10px 14px; border-radius:16px; background: color-mix(in srgb, var(--surface-2), transparent 18%); border:1px solid color-mix(in srgb, var(--border-1), transparent 25%); box-shadow: inset 0 0 0 1px rgba(255,255,255,.04), 0 8px 18px rgba(15,23,42,.28); transition: box-shadow .35s ease, opacity .35s ease; }
+.light .schedule-chip{ background: rgba(255,255,255,.85); border:1px solid rgba(15,23,42,.08); box-shadow: inset 0 0 0 1px rgba(255,255,255,.6); }
+.schedule-chip--active{ background: linear-gradient(135deg, rgba(168,85,247,.35), rgba(236,72,153,.3)); border-color: transparent; box-shadow: 0 16px 32px rgba(168,85,247,.32); }
+.light .schedule-chip--active{ background: linear-gradient(135deg, rgba(233,213,255,.85), rgba(244,163,205,.72)); box-shadow: 0 18px 32px rgba(168,85,247,.22); }
+.schedule-chip__icon{ width:36px; height:36px; border-radius:12px; display:inline-flex; align-items:center; justify-content:center; background: linear-gradient(135deg, rgba(14,165,233,.42), rgba(99,102,241,.42)); color:#fff; box-shadow: 0 10px 22px rgba(99,102,241,.24); }
+.schedule-chip--active .schedule-chip__icon{ background: linear-gradient(135deg, rgba(236,72,153,.6), rgba(168,85,247,.6)); box-shadow: 0 14px 32px rgba(236,72,153,.32); }
+.light .schedule-chip__icon{ background: linear-gradient(135deg, rgba(14,165,233,.7), rgba(99,102,241,.7)); }
+.schedule-chip--break:not(.schedule-chip--active){
+  background: color-mix(in srgb, rgba(253,186,116,.22), var(--surface-2) 75%);
+  border-color: color-mix(in srgb, rgba(253,186,116,.45), transparent 68%);
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,.05), 0 8px 18px rgba(253,186,116,.24);
+}
+.light .schedule-chip--break:not(.schedule-chip--active){
+  background: color-mix(in srgb, rgba(253,186,116,.32), white 78%);
+  border-color: rgba(253,186,116,.45);
+}
+.schedule-chip--break .schedule-chip__icon{
+  background: linear-gradient(135deg, rgba(251,191,36,.68), rgba(251,113,133,.56));
+  box-shadow: 0 10px 24px rgba(251,191,36,.28);
+}
+.schedule-chip--final:not(.schedule-chip--active){
+  background: color-mix(in srgb, rgba(253,224,71,.26), var(--surface-2) 68%);
+  border-color: color-mix(in srgb, rgba(253,224,71,.45), transparent 68%);
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,.05), 0 10px 22px rgba(253,224,71,.24);
+}
+.light .schedule-chip--final:not(.schedule-chip--active){
+  background: color-mix(in srgb, rgba(253,224,71,.36), white 76%);
+  border-color: rgba(253,224,71,.45);
+}
+.schedule-chip--final .schedule-chip__icon{
+  background: linear-gradient(135deg, rgba(234,179,8,.78), rgba(253,224,71,.68));
+  color:#2f2a16;
+  box-shadow: 0 10px 24px rgba(234,179,8,.32);
+}
+.schedule-chip__content{ display:flex; flex-direction:column; gap:2px; }
+.schedule-chip__label{ font-size:.8rem; color: var(--text-2); letter-spacing:.02em; text-transform:capitalize; }
+.light .schedule-chip__label{ color: color-mix(in srgb, var(--text-2), black 10%); }
+.schedule-chip__time{ font-size:1rem; font-weight:600; color: var(--text-1); letter-spacing:.04em; }
+.schedule-chip--active .schedule-chip__time{ color:#fdf4ff; }
+.light .schedule-chip--active .schedule-chip__time{ color:#1e1b4b; }
+.schedule-card--compact{ padding:16px 18px 18px !important; border-radius:20px !important; }
+.schedule-card--compact .schedule-card__header{ margin-bottom:9px; }
+.schedule-card--compact .schedule-card__list{ gap:8px; }
+.schedule-card--compact .schedule-chip{ padding:9px 12px; border-radius:14px; gap:9px; }
+.schedule-card--compact .schedule-chip__icon{ width:30px; height:30px; border-radius:11px; box-shadow: 0 8px 18px rgba(99,102,241,.2); }
+.schedule-card--compact .schedule-chip__label{ font-size:.74rem; }
+.schedule-card--compact .schedule-chip__time{ font-size:.92rem; }
+.schedule-card--tight .schedule-card__list{ flex-wrap:nowrap; overflow-x:auto; padding-bottom:4px; }
+.schedule-card--tight .schedule-chip{ flex:1 0 auto; min-width:0; }
+.schedule-card--tight .schedule-chip__time{ white-space:nowrap; }
+.schedule-card--expanded{ padding:28px 32px 30px !important; border-radius:30px !important; }
+.schedule-card--expanded .schedule-chip{ padding:14px 18px; }
+.schedule-card--expanded .schedule-chip__icon{ width:44px; height:44px; border-radius:16px; }
 
 .hud-topbar { position: relative; }
 .hud-topbar::after { content: ""; position: absolute; inset-inline: 12px; bottom: -1px; height: 1px; opacity:.5; background: linear-gradient(90deg, transparent, rgba(99,102,241,.32), transparent); }
@@ -290,8 +679,8 @@ body { overscroll-behavior: none; background: #000; -webkit-font-smoothing: anti
 
 /* ===== Motion safe/reduce ===== */
 @media (prefers-reduced-motion: reduce) {
-  .animate-gridPan, .orb, .progress-stripes, .animate-flipTick, .title-shine, .swap-fade, .sweep, .brand-shine,
-  .progress-fill::before, .progress-fill::after { animation: none !important; }
+  .animate-gridPan, .orb, .animate-flipTick, .title-shine, .swap-fade, .sweep, .brand-shine { animation: none !important; }
+  .progress-beam__fill, .progress-beam__glow, .progress-beam__spark, .progress-beam__shine { transition: none !important; animation: none !important; }
 }
 @media (update: slow){
   :root{ --hud-progress-speed: .75s; --hud-streak-fast: 2.2s; --hud-streak-slow: 4s; }
@@ -302,8 +691,10 @@ body { overscroll-behavior: none; background: #000; -webkit-font-smoothing: anti
   :root{ --hud-grid-alpha: 0.08; }
   .hud-frame::before{ border-top-color: rgba(255,255,255,.14); border-bottom-color: rgba(255,255,255,.12); }
   .light .hud-frame::before{ border-top-color: rgba(0,0,0,.18); border-bottom-color: rgba(0,0,0,.14); }
-  .neon-progress{ box-shadow: inset 0 0 0 1px rgba(255,255,255,.18); }
-  .light .neon-progress{ box-shadow: inset 0 0 0 1px rgba(0,0,0,.18); }
+  .progress-panel{ box-shadow: inset 0 0 0 1px rgba(255,255,255,.18); }
+  .light .progress-panel{ box-shadow: inset 0 0 0 1px rgba(0,0,0,.18); }
+  .progress-beam{ box-shadow: inset 0 0 0 2px rgba(255,255,255,.24); }
+  .light .progress-beam{ box-shadow: inset 0 0 0 2px rgba(0,0,0,.24); }
 }
 
 /* ===== Forced colors ===== */
@@ -311,8 +702,9 @@ body { overscroll-behavior: none; background: #000; -webkit-font-smoothing: anti
   * { forced-color-adjust: none; }
   .bg-grid, .noise-layer, .scanlines, .orb, .ambient-rail, .ambient-rail--light, .ux-foil, .ux-aurora, .ux-grid, .ux-sheen { display:none; }
   .hud-frame, .hud-topbar, .hud-card { background: Canvas; border: 1px solid CanvasText; color: CanvasText; }
-  .neon-progress{ background: Canvas; box-shadow: none; }
-  .progress-stripes{ background: CanvasText !important; animation: none !important; }
+  .progress-panel{ background: Canvas; border: 1px solid CanvasText; box-shadow: none; color: CanvasText; }
+  .progress-beam{ background: Canvas; border: 1px solid CanvasText; box-shadow: none; }
+  .progress-beam__fill{ background: CanvasText !important; }
 }
 
 /* ===== Backdrop filter fallback ===== */
@@ -366,6 +758,9 @@ body { overscroll-behavior: none; background: #000; -webkit-font-smoothing: anti
 .light .sigad-noti-text{ color: var(--text-1); text-shadow: none; }
 .light .sigad-noti-close{ color: #475569; }
 .light .sigad-noti-close:hover{ background: rgba(2,6,23,.06); color: #0f172a; }
+.display-shell .sigad-noti:hover .sigad-noti-progress{ animation-play-state: running; }
+.display-shell .sigad-noti-close:hover{ background: transparent; color: inherit; transform:none; }
+.display-shell.light .sigad-noti-close:hover{ background: transparent; color: inherit; }
 
 .sigad-noti-enter{ animation: sigad-in .22s cubic-bezier(.2,.8,.2,1) both; }
 @keyframes sigad-in{ from{ opacity:0; transform:translateY(-6px) scale(.98); } to  { opacity:1; transform:translateY(0)    scale(1); } }
@@ -437,7 +832,7 @@ body { overscroll-behavior: none; background: #000; -webkit-font-smoothing: anti
   pointer-events: none;
 }
 @media (prefers-reduced-motion:no-preference){
-  .logo-badge--fx::before{
+.logo-badge--fx::before{
     content: "";
     position: absolute;
     inset: -8px;
@@ -450,3 +845,98 @@ body { overscroll-behavior: none; background: #000; -webkit-font-smoothing: anti
     pointer-events: none;
   }
 }
+
+/* ===== Header menu compacto ===== */
+.header-menu{
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: min(240px, 80vw);
+  background: linear-gradient(180deg, rgba(15,18,28,.92), rgba(10,12,18,.88));
+  border: 1px solid rgba(255,255,255,.08);
+  border-radius: 12px;
+  padding: 12px;
+  z-index: 1200;
+  color: #e5e7eb;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+.light .header-menu{
+  background: linear-gradient(180deg, rgba(248,250,255,.96), rgba(236,238,245,.95));
+  border-color: rgba(15,23,42,.08);
+  color: #0f172a;
+}
+.header-menu__section + .header-menu__section{ margin-top: 12px; }
+.header-menu__label{ font-size: .75rem; text-transform: uppercase; letter-spacing: .04em; opacity: .72; margin-bottom: 6px; color: inherit; }
+.light .header-menu__label{ opacity: .85; color: rgba(15,23,42,.72); }
+.header-menu__item{
+  display: block;
+  width: 100%;
+  border: 0;
+  background: rgba(148,163,184,.12);
+  color: inherit;
+  padding: 6px 10px;
+  border-radius: 8px;
+  text-align: left;
+  transition: background-color .18s ease, color .18s ease, box-shadow .18s ease;
+}
+.header-menu__item:hover{ background: rgba(148,163,184,.22); color: inherit; }
+.header-menu__item:focus-visible{ outline: 2px solid rgba(148,163,184,.45); outline-offset: 2px; box-shadow: 0 0 0 2px rgba(148,163,184,.18); }
+.light .header-menu__item{ background: rgba(15,23,42,.08); }
+.light .header-menu__item:hover{ background: rgba(15,23,42,.14); }
+.light .header-menu__item:focus-visible{ outline-color: rgba(15,23,42,.38); box-shadow: 0 0 0 2px rgba(15,23,42,.14); }
+
+/* ===== Itinerario dialog ===== */
+.itinerary-overlay{ position: fixed; inset:0; z-index:2600; display:flex; align-items:center; justify-content:center; }
+.itinerary-backdrop{ position:absolute; inset:0; background:rgba(0,0,0,.55); backdrop-filter: blur(3px); }
+.itinerary-modal{
+  position: relative;
+  width: min(860px, 92vw);
+  max-height: calc(100vh - 80px);
+  overflow-y: auto;
+  border-radius: 16px;
+  border: 1px solid rgba(255,255,255,.08);
+  background: linear-gradient(180deg, rgba(15,16,24,.94), rgba(10,12,20,.94));
+  color: #e5e7eb;
+  padding: 20px 22px;
+  box-shadow: 0 20px 60px rgba(0,0,0,.55);
+}
+.light .itinerary-modal{
+  background: linear-gradient(180deg, rgba(255,255,255,.96), rgba(245,247,252,.95));
+  border-color: rgba(15,23,42,.08);
+  color: #0f172a;
+}
+.itinerary-modal__header{ display:flex; align-items:center; justify-content:space-between; gap:16px; margin-bottom:16px; }
+.itinerary-modal__body{ display:grid; gap:16px; }
+.itinerary-card{
+  border: 1px solid rgba(255,255,255,.06);
+  border-radius: 12px;
+  padding: 14px 16px;
+  background: linear-gradient(180deg, rgba(17,19,28,.85), rgba(12,14,22,.9));
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.05);
+}
+.light .itinerary-card{
+  border-color: rgba(15,23,42,.08);
+  background: linear-gradient(180deg, rgba(255,255,255,.92), rgba(242,244,249,.92));
+}
+.itinerary-card__header{ display:flex; align-items:center; justify-content:space-between; gap:12px; margin-bottom:8px; }
+.itinerary-card__meta{ display:flex; flex-wrap:wrap; gap:12px; font-size:.75rem; opacity:.75; margin-bottom:8px; }
+.itinerary-card__list{ list-style:none; padding:0; margin:0; display:grid; gap:6px; font-size:.85rem; }
+.itinerary-card__list li{ display:flex; justify-content:space-between; gap:12px; }
+.itinerary-card__list strong{ font-variant-numeric: tabular-nums; }
+.itinerary-card__empty{ font-size:.8rem; opacity:.65; padding:4px 0 2px; }
+
+/* ===== Card details ===== */
+.card-advanced-actions{
+  border-radius: 10px;
+  border: 1px solid rgba(148,163,184,.18);
+  padding: 8px 12px;
+  background: rgba(15,23,42,.25);
+}
+.card-advanced-actions summary{
+  cursor: pointer;
+  list-style: none;
+}
+.card-advanced-actions[open]{ background: rgba(15,23,42,.35); }
+.light .card-advanced-actions{ background: rgba(15,23,42,.06); border-color: rgba(15,23,42,.12); }
+.light .card-advanced-actions[open]{ background: rgba(15,23,42,.1); }


### PR DESCRIPTION
## Summary
- allow `computeSchedule` to return full milestone lists so the itinerary modal and clipboard export include every event
- normalize display preview iframe ids when reloading to restore skeleton feedback and keep HUD menus well-formed
- refine header menu styling for clearer light-theme contrast and accessible focus states

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca22d35e648322a95870ab1d0e60e3